### PR TITLE
Add second dropdown for all menu items under 640px, update layout and margins for small screens 

### DIFF
--- a/src/components/BlogIndex.astro
+++ b/src/components/BlogIndex.astro
@@ -14,14 +14,14 @@ interface Props {
 <ul class={`list-none pl-0 ${className}`}>
   {
     displayPosts.map((post) => (
-      <li class="flex flex-col justify-between border-b-[0.5px] p-2.5 sm:flex-row dark:border-slate-400/20">
-        <div class="mb-2 text-slate-600/75 sm:mb-0 dark:text-slate-200/60">
+      <li class="grid grid-cols-1 border-b-[0.5px] p-2.5 sm:grid-cols-3 dark:border-slate-400/20">
+        <div class="col-span-1 self-center text-slate-600/75 dark:text-slate-200/60">
           {post.frontmatter.pubDate}
         </div>
-        <div>
+        <div class="col-span-2 sm:text-right">
           <a
             href={post.url}
-            class="text-xl font-[600] text-slate-700 underline decoration-sky-500 decoration-2 underline-offset-[5px] hover:text-slate-600/80 hover:decoration-sky-300 dark:text-slate-200 dark:decoration-sky-500 dark:hover:text-slate-200/75 dark:hover:underline dark:hover:decoration-sky-600/80">
+            class="block text-xl font-[600] text-slate-700 underline decoration-sky-500 decoration-2 underline-offset-[5px] hover:text-slate-600/80 hover:decoration-sky-300 dark:text-slate-200 dark:decoration-sky-500 dark:hover:text-slate-200/75 dark:hover:underline dark:hover:decoration-sky-600/80">
             {post.frontmatter.title}
           </a>
         </div>

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -11,7 +11,7 @@ let { variant, displayHr } = Astro.props;
 ---
 
 <div
-  class={`prose prose-slate dark:prose-invert max-w-3xl p-6 prose-h2:font-semibold prose-h2:opacity-80 dark:prose-h2:opacity-60 ${
+  class={`prose prose-slate dark:prose-invert max-w-3xl mx-4 p-6 prose-h2:font-semibold prose-h2:opacity-80 dark:prose-h2:opacity-60 ${
     variant === 'borderless' ? '' : 'border-card'
   }`}>
   <h1 class="mb-2">{Astro.props.title}</h1>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -5,7 +5,7 @@ import ThemeToggle from './subComponents/ThemeToggle.astro';
 ---
 
 <div
-  class="navbar-container sticky top-0 z-10 mb-8 w-full border-b border-slate-400/50 bg-white px-3 py-1 sm:px-6 md:px-10 md:py-2 xl:px-14 dark:border-slate-400/40 dark:bg-slate-950">
+  class="navbar-container sticky top-0 z-10 mb-8 w-full border-b border-slate-400/50 bg-white  px-4 sm:px-6 md:px-10 py-2 xl:px-14 dark:border-slate-400/40 dark:bg-slate-950">
   <div class="button-container flex items-center justify-between gap-6">
     <a href="/">
       <img
@@ -16,20 +16,26 @@ import ThemeToggle from './subComponents/ThemeToggle.astro';
       <img
         src="../astroLogoSmall.svg"
         alt="Astro Logo"
-        class="astro-icon h-8 w-8 opacity-80 sm:block md:hidden"
+        class="astro-icon h-8 w-8 opacity-80 block md:hidden"
       />
     </a>
-    <div class="md:text-md flex lg:text-lg">
-      <Button name="Home" link="/" />
-      <Button name="About" link="/about" />
-      <Button name="Blog" link="/blog" />
-      <DropdownMenu
-        name="Projects"
-        links={[
-          { name: 'Minimal Typography', url: '/designProject' },
-          { name: 'Old Flask Site', url: '/flaskSite' },
-        ]}
-      />
+    <div class="button-theme-container flex">
+      <div class="md:text-md hidden sm:flex lg:text-lg">
+        <Button name="Home" link="/" />
+        <Button name="About" link="/about" />
+        <Button name="Blog" link="/blog" />
+        <DropdownMenu
+          name="Projects"
+          links={[
+            { name: 'Minimal Typography', url: '/designProject' },
+            { name: 'Old Flask Site', url: '/flaskSite' },
+          ]}
+          showCaret={true}
+        />
+      </div>
+      <div class="flex sm:hidden">
+
+      </div>
       <ThemeToggle />
     </div>
   </div>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -19,7 +19,8 @@ import ThemeToggle from './subComponents/ThemeToggle.astro';
         class="astro-icon h-8 w-8 opacity-80 block md:hidden"
       />
     </a>
-      <div class="md:text-md flex lg:text-lg">
+    <div class="button-theme-container flex">
+      <div class="md:text-md hidden sm:flex lg:text-lg">  
         <Button name="Home" link="/" />
         <Button name="About" link="/about" />
         <Button name="Blog" link="/blog" />
@@ -32,7 +33,11 @@ import ThemeToggle from './subComponents/ThemeToggle.astro';
           showCaret={true}
           icon={false}
         />
-      <ThemeToggle />
+      </div>
+      <div class="flex sm:hidden">
+
+      </div>
+        <ThemeToggle />
     </div>
   </div>
 </div>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -19,8 +19,7 @@ import ThemeToggle from './subComponents/ThemeToggle.astro';
         class="astro-icon h-8 w-8 opacity-80 block md:hidden"
       />
     </a>
-    <div class="button-theme-container flex">
-      <div class="md:text-md hidden sm:flex lg:text-lg">
+      <div class="md:text-md flex lg:text-lg">
         <Button name="Home" link="/" />
         <Button name="About" link="/about" />
         <Button name="Blog" link="/blog" />
@@ -31,24 +30,8 @@ import ThemeToggle from './subComponents/ThemeToggle.astro';
             { name: 'Old Flask Site', url: '/flaskSite' },
           ]}
           showCaret={true}
-          dropdownType="desktop"
+          icon={false}
         />
-      </div>
-      <div class="flex sm:hidden">
-        <DropdownMenu 
-          name='hamburger'
-          links={[
-            { name: 'Home', url: '/' },
-            { name: 'About', url: '/about' },
-            { name: 'Blog', url: '/blog' },
-            { name: 'Minimal Typography', url: '/designProject' },
-            { name: 'Old Flask Site', url: '/flaskSite' },
-          ]}
-          showCaret={false}
-          icon={true}
-          dropdownType="mobile"
-        />
-      </div>
       <ThemeToggle />
     </div>
   </div>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -31,10 +31,23 @@ import ThemeToggle from './subComponents/ThemeToggle.astro';
             { name: 'Old Flask Site', url: '/flaskSite' },
           ]}
           showCaret={true}
+          dropdownType="desktop"
         />
       </div>
       <div class="flex sm:hidden">
-
+        <DropdownMenu 
+          name='hamburger'
+          links={[
+            { name: 'Home', url: '/' },
+            { name: 'About', url: '/about' },
+            { name: 'Blog', url: '/blog' },
+            { name: 'Minimal Typography', url: '/designProject' },
+            { name: 'Old Flask Site', url: '/flaskSite' },
+          ]}
+          showCaret={false}
+          icon={true}
+          dropdownType="mobile"
+        />
       </div>
       <ThemeToggle />
     </div>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -35,7 +35,17 @@ import ThemeToggle from './subComponents/ThemeToggle.astro';
         />
       </div>
       <div class="flex sm:hidden">
-
+        <DropdownMenu
+          name="hamburger"
+          links={[
+            { name: 'Home', url: '/' },
+            { name: 'About', url: '/about' },
+            { name: 'Blog', url: '/blog' },
+            { name: 'Minimal Typography', url: '/designProject' },
+            { name: 'Old Flask Site', url: '/flaskSite' },
+          ]}
+          showCaret={false}
+          icon={true} />
       </div>
         <ThemeToggle />
     </div>

--- a/src/components/subComponents/Button.astro
+++ b/src/components/subComponents/Button.astro
@@ -8,7 +8,7 @@ interface Props {
   icon?: boolean;
 }
 
-const { name, link, id, showCaret = false, class: className, icon = false } = Astro.props;
+const { name, link, id, showCaret = false, class: className, icon = false, ...rest } = Astro.props;
 import { Icon } from 'astro-icon/components';
 ---
 
@@ -16,8 +16,8 @@ import { Icon } from 'astro-icon/components';
   href={link}
   id={id}
   class=`mx-2 flex rounded-lg px-3 py-2 font-normal dark:text-slate-200 hover:bg-slate-200/50 dark:hover:bg-slate-800 hover:text-opacity-100 transition-color duration-200 max-w-max ${className} ${showCaret ? 'pr-1.5' : ''}`>
-  <button class="flex" aria-label={name}>
-    {icon ? <Icon name={name} title={name} size={20} /> : name}
+  <button class="flex" aria-label={name} {...rest}>
+    {icon ? <Icon name={name} title={name} size={26} /> : name}
     {
       showCaret && (
         <svg

--- a/src/components/subComponents/Button.astro
+++ b/src/components/subComponents/Button.astro
@@ -5,9 +5,11 @@ interface Props {
   id?: string;
   showCaret?: boolean;
   class?: string;
+  icon?: boolean;
 }
 
-const { name, link, id, showCaret = false, class: className } = Astro.props;
+const { name, link, id, showCaret = false, class: className, icon = false } = Astro.props;
+import { Icon } from 'astro-icon/components';
 ---
 
 <a
@@ -15,7 +17,7 @@ const { name, link, id, showCaret = false, class: className } = Astro.props;
   id={id}
   class=`mx-2 flex rounded-lg px-3 py-2 font-normal dark:text-slate-200 hover:bg-slate-200/50 dark:hover:bg-slate-800 hover:text-opacity-100 transition-color duration-200 max-w-max ${className} ${showCaret ? 'pr-1.5' : ''}`>
   <button class="flex" aria-label={name}>
-    {name}
+    {icon ? <Icon name={name} title={name} size={20} /> : name}
     {
       showCaret && (
         <svg

--- a/src/components/subComponents/Button.astro
+++ b/src/components/subComponents/Button.astro
@@ -8,7 +8,7 @@ interface Props {
   icon?: boolean;
 }
 
-const { name, link, id, showCaret = false, class: className, icon = false, ...rest } = Astro.props;
+const { name, link, id, showCaret = false, class: className, icon = false } = Astro.props;
 import { Icon } from 'astro-icon/components';
 ---
 
@@ -16,7 +16,7 @@ import { Icon } from 'astro-icon/components';
   href={link}
   id={id}
   class=`mx-2 flex rounded-lg px-3 py-2 font-normal dark:text-slate-200 hover:bg-slate-200/50 dark:hover:bg-slate-800 hover:text-opacity-100 transition-color duration-200 max-w-max ${className} ${showCaret ? 'pr-1.5' : ''}`>
-  <button class="flex" aria-label={name} {...rest}>
+  <button class="flex" aria-label={name}>
     {icon ? <Icon name={name} title={name} size={26} /> : name}
     {
       showCaret && (

--- a/src/components/subComponents/DropdownMenu.astro
+++ b/src/components/subComponents/DropdownMenu.astro
@@ -8,14 +8,15 @@ interface Props {
   name: string;
   links: Link[];
   showCaret?: boolean;
+  icon?: boolean;
 }
 
-const { name = 'Dropdown', links = [], showCaret = false } = Astro.props;
+const { name = 'Dropdown', links = [], showCaret = false, icon = false } = Astro.props;
 import Button from './Button.astro';
 ---
 
 <div class="relative">
-  <Button name={name} id="dropdown-button" showCaret={showCaret} />
+  <Button name={name} id="dropdown-button" showCaret={showCaret} icon={icon} />
   <div
     id="dropdown"
     class="absolute mt-1 hidden text-balance rounded-md bg-slate-200/50 p-[0.5px] backdrop-blur-md sm:ml-2 md:w-40 dark:bg-slate-800">

--- a/src/components/subComponents/DropdownMenu.astro
+++ b/src/components/subComponents/DropdownMenu.astro
@@ -7,19 +7,18 @@ interface Link {
 interface Props {
   name: string;
   links: Link[];
-  showCaret?: boolean;
-  icon?: boolean;
-  dropdownType?: 'desktop' | 'mobile';
+  showCaret: boolean;
+  icon: boolean;
 }
 
-const { name = 'Dropdown', links = [], showCaret = false, icon = false, dropdownType = 'desktop' } = Astro.props;
+const { name = 'Dropdown', links = [], showCaret = false, icon = false } = Astro.props;
 import Button from './Button.astro';
 ---
 
 <div class="relative">
-  <Button name={name} data-dropdown-type={dropdownType} showCaret={showCaret} icon={icon} /> 
+  <Button name={name} id="dropdown-button" showCaret={showCaret} icon={icon} /> 
   <div
-    data-dropdown={dropdownType}
+    id="dropdown"
     class="absolute mt-1 hidden text-balance rounded-md bg-slate-200/50 p-[0.5px] backdrop-blur-md sm:ml-2 md:w-40 dark:bg-slate-800">
     {
       links.map((link) => (
@@ -34,29 +33,17 @@ import Button from './Button.astro';
 </div>
 
 <script>
-document.querySelectorAll('[data-dropdown-type]').forEach(button => {
-  button.addEventListener('click', (event) => {
-    const dropdownType = button.getAttribute('data-dropdown-type');
-    const dropdown = document.querySelector(`[data-dropdown="${dropdownType}"]`);
-    
-    if (window.matchMedia('(min-width: 640px)').matches && dropdownType === 'mobile') {
-      return; // Skip for mobile dropdown on desktop view
-    }
+  const button = document.getElementById('dropdown-button');
+  const dropdown = document.getElementById('dropdown');
 
-    if (window.matchMedia('(max-width: 639px)').matches && dropdownType === 'desktop') {
-      return; // Skip for desktop dropdown on mobile view
-    }
-    
+  button.addEventListener('click', (event) => {
     dropdown.classList.toggle('hidden');
     button.classList.toggle('dropdown-active');
     event.stopPropagation();
   });
-});
 
-document.addEventListener('click', (event) => {
-    document.querySelectorAll('[data-dropdown]').forEach(dropdown => {
-      dropdown.classList.add('hidden');
-    });
-  }
-);
+  document.addEventListener('click', () => {
+    button.classList.remove('dropdown-active');
+    dropdown.classList.add('hidden');
+  });
 </script>

--- a/src/components/subComponents/DropdownMenu.astro
+++ b/src/components/subComponents/DropdownMenu.astro
@@ -9,16 +9,17 @@ interface Props {
   links: Link[];
   showCaret?: boolean;
   icon?: boolean;
+  dropdownType?: 'desktop' | 'mobile';
 }
 
-const { name = 'Dropdown', links = [], showCaret = false, icon = false } = Astro.props;
+const { name = 'Dropdown', links = [], showCaret = false, icon = false, dropdownType = 'desktop' } = Astro.props;
 import Button from './Button.astro';
 ---
 
 <div class="relative">
-  <Button name={name} id="dropdown-button" showCaret={showCaret} icon={icon} />
+  <Button name={name} data-dropdown-type={dropdownType} showCaret={showCaret} icon={icon} /> 
   <div
-    id="dropdown"
+    data-dropdown={dropdownType}
     class="absolute mt-1 hidden text-balance rounded-md bg-slate-200/50 p-[0.5px] backdrop-blur-md sm:ml-2 md:w-40 dark:bg-slate-800">
     {
       links.map((link) => (
@@ -33,17 +34,29 @@ import Button from './Button.astro';
 </div>
 
 <script>
-  const button = document.getElementById('dropdown-button');
-  const dropdown = document.getElementById('dropdown');
-
+document.querySelectorAll('[data-dropdown-type]').forEach(button => {
   button.addEventListener('click', (event) => {
+    const dropdownType = button.getAttribute('data-dropdown-type');
+    const dropdown = document.querySelector(`[data-dropdown="${dropdownType}"]`);
+    
+    if (window.matchMedia('(min-width: 640px)').matches && dropdownType === 'mobile') {
+      return; // Skip for mobile dropdown on desktop view
+    }
+
+    if (window.matchMedia('(max-width: 639px)').matches && dropdownType === 'desktop') {
+      return; // Skip for desktop dropdown on mobile view
+    }
+    
     dropdown.classList.toggle('hidden');
     button.classList.toggle('dropdown-active');
     event.stopPropagation();
   });
+});
 
-  document.addEventListener('click', () => {
-    button.classList.remove('dropdown-active');
-    dropdown.classList.add('hidden');
-  });
+document.addEventListener('click', (event) => {
+    document.querySelectorAll('[data-dropdown]').forEach(dropdown => {
+      dropdown.classList.add('hidden');
+    });
+  }
+);
 </script>

--- a/src/components/subComponents/DropdownMenu.astro
+++ b/src/components/subComponents/DropdownMenu.astro
@@ -15,11 +15,10 @@ const { name = 'Dropdown', links = [], showCaret = false, icon = false } = Astro
 import Button from './Button.astro';
 ---
 
-<div class="relative">
-  <Button name={name} id="dropdown-button" showCaret={showCaret} icon={icon} /> 
+<div class="relative dropdown">
+  <Button name={name} class="dropdown-button" showCaret={showCaret} icon={icon} /> 
   <div
-    id="dropdown"
-    class="absolute mt-1 hidden text-balance rounded-md bg-slate-200/50 p-[0.5px] backdrop-blur-md sm:ml-2 md:w-40 dark:bg-slate-800">
+    class="dropdown-content absolute mt-1 hidden text-balance rounded-md bg-slate-200/50 p-[0.5px] backdrop-blur-md sm:ml-2 md:w-40 dark:bg-slate-800">
     {
       links.map((link) => (
         <a
@@ -33,17 +32,23 @@ import Button from './Button.astro';
 </div>
 
 <script>
-  const button = document.getElementById('dropdown-button');
-  const dropdown = document.getElementById('dropdown');
+  const dropdowns = document.querySelectorAll('.dropdown');
+
+dropdowns.forEach((dropdown) => {
+  const button = dropdown.querySelector('.dropdown-button');
+  const content = dropdown.querySelector('.dropdown-content');
 
   button.addEventListener('click', (event) => {
-    dropdown.classList.toggle('hidden');
+    content.classList.toggle('hidden');
     button.classList.toggle('dropdown-active');
     event.stopPropagation();
   });
 
   document.addEventListener('click', () => {
-    button.classList.remove('dropdown-active');
-    dropdown.classList.add('hidden');
+    if (!dropdown.contains(event.target as Node)) {
+      button.classList.remove('dropdown-active');
+      content.classList.add('hidden');
+    }
   });
+});
 </script>

--- a/src/icons/hamburger.svg
+++ b/src/icons/hamburger.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+  </svg>

--- a/src/layouts/MDLayout.astro
+++ b/src/layouts/MDLayout.astro
@@ -35,7 +35,7 @@ import '/src/styles/global.css';
     </script>
   </head>
   <NavBar />
-  <div class="flex justify-center">
+  <div class="flex justify-center mx-6">
     <div class="xl:w-[240px]"></div>
     <article
       class="prose max-w-sm dark:prose-invert prose-h1:pt-2

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -10,7 +10,7 @@ import MainLayout from '../layouts/MainLayout.astro';
         class="mb-4 text-4xl font-extrabold text-slate-700 dark:text-slate-100">
         Blog Posts
       </h1>
-      <BlogIndex class="w-[500px] sm:w-[560px] md:w-[720px] lg:w-[860px]" />
+      <BlogIndex class="sm:w-[560px] md:w-[720px] lg:w-[860px]" />
     </div>
   </div>
 </MainLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,7 @@ import BlogIndex from '../components/BlogIndex.astro';
           pilot high-performance drones.
         </p>
       </Card>
-      <div class="mt-8 p-6">
+      <div class="mt-8 p-6 mx-4">
         <div class="prose mb-3 dark:prose-invert">
           <h1 class="">Latest Posts</h1>
         </div>


### PR DESCRIPTION
- Add second dropdown menu for all menu items on smaller screens
    - Update `DropdownMenu` to use classes instead of IDs for opening and closing, allowing multiple instances of `DropdownMenu` per page
    - Update script for new classes and add a check to ensure dropdown doesn't close when clicking within it 
    - Add Icon prop to `Button` to display an icon using astro-icon, using name prop to source the icon by it's name
```astro
<DropdownMenu
  name="hamburger"
  showCaret={false}
  icon={true} />
```

- Add `mx-4` margin on `MDLayout.astro` for blogs, `Card.astro`, and `Index.astro` to add space around elements on small screens