### PR TITLE
Improve ThemeToggle script, replace CSS with TW, add dark class to html to fix #19

### DIFF
--- a/src/components/subComponents/ThemeToggle.astro
+++ b/src/components/subComponents/ThemeToggle.astro
@@ -5,7 +5,7 @@
 <button
   id="themeToggle"
   aria-label="Dark Mode Toggle"
-  class="rounded-lg px-3 py-2">
+  class="ml-2 rounded-lg px-3 py-2">
   <svg width="26px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <path
       class="sun"
@@ -51,7 +51,8 @@
   };
 
   function applyTheme(theme) {
-    element.className = theme;
+    element.classList.remove('dark', 'light');
+    element.classList.add(theme);
     element.setAttribute('data-code-theme', themes[theme]);
     localStorage.setItem('themeToggle', theme);
   }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,7 +5,7 @@ import NavBar from '../components/NavBar.astro';
 const { description, title } = Astro.props;
 ---
 
-<html lang="en">
+<html lang="en" class="dark min-h-dvh scroll-pt-16">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -15,10 +15,11 @@ const { description, title } = Astro.props;
     <title>{title}</title>
     <slot name="head" />
   </head>
-  <NavBar />
-  <slot />
-  <Footer />
-
+  <body class="flex flex-col items-center">
+    <NavBar />
+    <slot />
+    <Footer />
+  </body>
   <style>
     :root {
       @apply bg-primary-50;
@@ -27,17 +28,5 @@ const { description, title } = Astro.props;
     :root.dark {
       @apply bg-primary-950;
     }
-
-    html {
-      min-height: 100dvh;
-      scroll-padding-top: 4rem;
-    }
-    body {
-      display: flex;
-      align-items: center;
-      flex-direction: column;
-    }
   </style>
-
-
 </html>


### PR DESCRIPTION
- [refactor(script):](https://github.com/AVGVSTVS96/astroSite/commit/4af35c899e5a6db3f7383a50b146540790203a1d) Use classList.add/remove instead of assigning theme to className
- [refactor(style):](https://github.com/AVGVSTVS96/astroSite/commit/7b9acdd147075f951b88296a176e4952bc0bed51) Use TW classes for html, body tags, add dark class to HTML fixes #19