### PR TITLE
Refactor: Use recursive component for `TableOfContentsHeading`

### DIFF
--- a/src/components/TableOfContentsHeading.astro
+++ b/src/components/TableOfContentsHeading.astro
@@ -1,55 +1,32 @@
 ---
-const { class: className, heading } = Astro.props;
+const { class: className, heading, isSubheading } = Astro.props;
 import { Icon } from 'astro-icon/components';
 ---
 
 <li class={className}>
-  <a href={'#' + heading.slug} class="no-underline">
+  <a href={'#' + heading.slug} class="group mt-1 flex items-start no-underline">
+    {
+      isSubheading && (
+        <Icon
+          name="sideCaret"
+          size={13}
+          class="mx-1 mt-1 flex-shrink-0 stroke-primary-600 group-hover:stroke-primary-400/80 dark:stroke-primary-400 dark:group-hover:stroke-primary-300"
+          title="caret-icon"
+        />
+      )
+    }
     {heading.text}
   </a>
   {
     heading.subheadings.length > 0 && (
-      <ul class="my-0 list-none px-0">
-        {heading.subheadings.map(
-          (subheading: { slug: string; text: string, subheadings: any[] }) => (
-            <li class="px-0">
-              <a
-                href={'#' + subheading.slug}
-                class="group flex items-start no-underline">
-                <Icon
-                  name="sideCaret"
-                  size={13}
-                  class="mx-1 mt-1 flex-shrink-0 stroke-primary-600 group-hover:stroke-primary-400/80 dark:stroke-primary-400 dark:group-hover:stroke-primary-300"
-                  title="caret-icon"
-                />
-                {subheading.text}
-              </a>
-              {
-                subheading.subheadings && subheading.subheadings.length > 0 && (
-                  <ul class="my-0 list-none px-0">
-                    {subheading.subheadings.map(
-                      (subsubheading: { slug: string; text: string }) => (
-                        <li class="px-0">
-                          <a
-                            href={'#' + subsubheading.slug}
-                            class="group flex items-start no-underline">
-                            <Icon
-                              name="sideCaret"
-                              size={13}
-                              class="mr-1 ml-5 mt-1 flex-shrink-0 stroke-primary-400 group-hover:stroke-primary-400/50 dark:stroke-primary-500 dark:group-hover:stroke-primary-300"
-                              title="caret-icon"
-                            />
-                            {subsubheading.text}
-                          </a>
-                        </li>
-                      )
-                    )}
-                  </ul>
-                )
-              }
-            </li>
-          )
-        )}
+      <ul class={`${isSubheading ? 'ml-2' : ''} my-0 list-none px-0`}>
+        {heading.subheadings.map((subheading) => (
+          <Astro.self
+            className="px-0"
+            heading={subheading}
+            isSubheading={true}
+          />
+        ))}
       </ul>
     )
   }

--- a/src/components/TableOfContentsHeading.astro
+++ b/src/components/TableOfContentsHeading.astro
@@ -1,16 +1,16 @@
 ---
-const { class: className, heading, isSubheading } = Astro.props;
+const { class: className, heading, isSubheading, level = 0 } = Astro.props;
 import { Icon } from 'astro-icon/components';
 ---
 
 <li class={className}>
-  <a href={'#' + heading.slug} class="group mt-1 flex items-start no-underline">
+  <a href={'#' + heading.slug} class="flex group mt-1 items-start no-underline">
     {
       isSubheading && (
         <Icon
           name="sideCaret"
           size={13}
-          class="mx-1 mt-1 flex-shrink-0 stroke-primary-600 group-hover:stroke-primary-400/80 dark:stroke-primary-400 dark:group-hover:stroke-primary-300"
+          class={`mx-1 mt-1 flex-shrink-0 ${level === 2 ? 'stroke-primary-400 group-hover:stroke-primary-400/50 dark:stroke-primary-500' : 'stroke-primary-600 group-hover:stroke-primary-400/80 dark:stroke-primary-400'} dark:group-hover:stroke-primary-300`}
           title="caret-icon"
         />
       )
@@ -25,6 +25,7 @@ import { Icon } from 'astro-icon/components';
             className="px-0"
             heading={subheading}
             isSubheading={true}
+            level={level + 1}
           />
         ))}
       </ul>

--- a/src/components/TableOfContentsHeading.astro
+++ b/src/components/TableOfContentsHeading.astro
@@ -4,7 +4,7 @@ import { Icon } from 'astro-icon/components';
 ---
 
 <li class={className}>
-  <a href={'#' + heading.slug} class="flex group mt-1 items-start no-underline">
+  <a href={'#' + heading.slug} class="flex group mt-0 items-start no-underline">
     {
       isSubheading && (
         <Icon


### PR DESCRIPTION
* Update to recursive component for `TableOfContentsHeading`
  * Add `isSubheading` prop to add caret icons to subheadings
  * Add `level` prop to define styles based on heading level