### PR TITLE
Stop scrollbar from shifting page layout and add GPT Chat link to mobile menu

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -12,7 +12,8 @@ const { ...attrs } = Astro.props;
 ---
 
 <div
-  class="navbar-container sticky top-0 z-10 mb-8 w-full border-b border-base/50 bg-primary-50 px-4 py-2 dark:border-base/40 dark:bg-primary-950 sm:px-6 md:px-10 xl:px-14" {...attrs}>
+  class="navbar-container sticky top-0 z-10 mb-8 w-full border-b border-base/50 bg-primary-50 px-4 py-2 dark:border-base/40 dark:bg-primary-950 sm:px-6 md:px-10 xl:px-14"
+  {...attrs}>
   <div
     class="button-container flex items-center justify-between text-dark dark:text-light">
     <a href="/" aria-label="home button">
@@ -56,6 +57,7 @@ const { ...attrs } = Astro.props;
             { name: 'Blog', url: '/blog' },
             { name: 'Minimal Typography', url: '/designProject' },
             { name: 'Old Flask Site', url: '/flaskSite' },
+            { name: 'GPT Chat', url: '/gpt' },
           ]}
           showCaret={false}
           icon={true}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,7 +16,7 @@ const { description, title } = Astro.props;
     <title>{title}</title>
     <slot name="head" />
   </head>
-  <body class="flex flex-col items-center">
+  <body class="flex flex-col items-center min-w-[100dvw] min-h-[100dvh]">
     <NavBar />
     <slot />
     <Footer />


### PR DESCRIPTION
* fix: use `dvw` and `dvh` on `<body>` b35f2df fixes #52 

Prevents layout shifts between scrollable and non-scrollable content, scrollbar doesn't affect layout width, and adding `dvh` for height ensures everything works correctly on mobile

* add GPT Chat link to mobile dropdown menu 3a262b6