### PR TITLE
Add `flex-grow` to fix #82, add gradient to color icon, improve ThemeSwitcher code`

### DIFF
--- a/src/components/subComponents/ThemeSwitcher.astro
+++ b/src/components/subComponents/ThemeSwitcher.astro
@@ -70,6 +70,6 @@ const themeOptions = [
     width: var(--rainbow-width);
     height: var(--rainbow-width);
     border-radius: 50%;
-    background: var(--accent-500);
+    background: linear-gradient(to bottom left, var(--accent-300), var(--accent-700));
   }
 </style>

--- a/src/components/subComponents/ThemeSwitcher.astro
+++ b/src/components/subComponents/ThemeSwitcher.astro
@@ -27,7 +27,6 @@ const themeOptions = [
 
 <script is:inline>
   const changeTheme = (newTheme) => {
-    document.documentElement.removeAttribute('data-theme');
     document.documentElement.setAttribute('data-theme', newTheme);
     localStorage.setItem('themeSwitcher', newTheme);
   };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,9 +16,11 @@ const { description, title } = Astro.props;
     <title>{title}</title>
     <slot name="head" />
   </head>
-  <body class="flex flex-col items-center">
+  <body class="flex flex-col items-center min-h-screen">
     <NavBar />
-    <slot />
+    <main class="flex-grow">
+      <slot />
+    </main>
     <Footer />
   </body>
   <style>


### PR DESCRIPTION
- **remove unnecessary `removeAttribute`, `setAttribute` handles this**
- **Add flex grow to `<main>` tag surrounding slot, fixes #82 by keeping the footer at the bottom of the page when content is short**
- **Add gradient to `ThemeSwitcher` icon**
