### PR TITLE
Eliminate FOUC by initializing and applying theme in BaseLayout

### DIFF
--- a/src/components/subComponents/ThemeToggle.astro
+++ b/src/components/subComponents/ThemeToggle.astro
@@ -46,27 +46,19 @@ const { ...attrs } = Astro.props;
 </style>
 
 <script is:inline>
-  const element = document.documentElement;
-  const themeToggleButton = document.getElementById('themeToggle');
+  function toggleTheme() {
+    const currentTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
 
-  function applyTheme(theme) {
-    element.classList.remove('dark', 'light');
-    element.classList.add(theme);
-    localStorage.setItem('themeToggle', theme);
-  }
-
-  function initializeTheme() {
-    const storedTheme = localStorage.getItem('themeToggle') || 'dark';
-    if (['dark', 'light'].includes(storedTheme)) {
-      applyTheme(storedTheme);
-    }
-  }
-
-  function handleToggleClick() {
-    const newTheme = element.classList.contains('dark') ? 'light' : 'dark';
     applyTheme(newTheme);
+    localStorage.setItem('themeToggle', newTheme);
   }
 
-  initializeTheme();
-  themeToggleButton.addEventListener('click', handleToggleClick);
+  // Wait for the DOM to load before attaching event listener to button
+  document.addEventListener('DOMContentLoaded', () => {
+    const themeToggleButton = document.getElementById('themeToggle');
+    if (themeToggleButton) {
+      themeToggleButton.addEventListener('click', toggleTheme);
+    }
+  });
 </script>

--- a/src/components/subComponents/ThemeToggle.astro
+++ b/src/components/subComponents/ThemeToggle.astro
@@ -47,18 +47,19 @@ const { ...attrs } = Astro.props;
 
 <script is:inline>
   function toggleTheme() {
-    const currentTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+    const currentTheme =
+      localStorage.getItem('theme') ||
+      (window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light');
     const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
 
-    applyTheme(newTheme);
-    localStorage.setItem('themeToggle', newTheme);
+    document.documentElement.classList.toggle('dark', newTheme === 'dark');
+    localStorage.setItem('theme', newTheme);
   }
 
-  // Wait for the DOM to load before attaching event listener to button
   document.addEventListener('DOMContentLoaded', () => {
     const themeToggleButton = document.getElementById('themeToggle');
-    if (themeToggleButton) {
-      themeToggleButton.addEventListener('click', toggleTheme);
-    }
+    themeToggleButton?.addEventListener('click', toggleTheme);
   });
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,35 +15,23 @@ const { description, title } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
     <title>{title}</title>
-    <slot name="head" />
     <script is:inline>
-      // Function to retrieve the user's theme preference from localStorage or system settings
-      function getPreferredTheme() {
-        const storedTheme = localStorage.getItem('themeToggle');
-        if (storedTheme) {
-          return storedTheme;
-        }
-        return window.matchMedia('(prefers-color-scheme: dark)').matches
+      const preferredTheme =
+        localStorage.getItem('theme') ||
+        (window.matchMedia('(prefers-color-scheme: dark)').matches
           ? 'dark'
-          : 'light';
-      }
+          : 'light');
+      document.documentElement.classList.toggle(
+        'dark',
+        preferredTheme === 'dark'
+      );
 
-      // Function to apply a given theme by updating the class list of the document element
-      function applyTheme(theme) {
-        document.documentElement.classList.toggle('dark', theme === 'dark');
-        document.documentElement.classList.toggle('light', theme === 'light');
-      }
-
-      // Initialize the theme when the page loads
-      const initialTheme = getPreferredTheme();
-      applyTheme(initialTheme);
-
-      // Update the theme automatically across all tabs when it's changed
       window.addEventListener('storage', () => {
-        const updatedTheme = getPreferredTheme();
-        applyTheme(updatedTheme);
+        const isDark = localStorage.getItem('theme') === 'dark';
+        document.documentElement.classList.toggle('dark', isDark);
       });
     </script>
+    <slot name="head" />
   </head>
   <body class="flex min-h-screen flex-col items-center">
     <NavBar />
@@ -53,17 +41,3 @@ const { description, title } = Astro.props;
     <Footer />
   </body>
 </html>
-
-<script is:inline>
-  const preferredTheme =
-    localStorage.getItem('theme') ||
-    (window.matchMedia('(prefers-color-scheme: dark)').matches
-      ? 'dark'
-      : 'light');
-  document.documentElement.classList.toggle('dark', preferredTheme === 'dark');
-
-  window.addEventListener('storage', () => {
-    const isDark = localStorage.getItem('theme') === 'dark';
-    document.documentElement.classList.toggle('dark', isDark);
-  });
-</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,8 +7,33 @@ import '@styles/shad.css';
 const { description, title } = Astro.props;
 
 ---
+<script is:inline>
+  // Function to retrieve the user's theme preference from localStorage or system settings
+  function getPreferredTheme() {
+    const storedTheme = localStorage.getItem('themeToggle');
+    if (storedTheme) {
+      return storedTheme;
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
 
-<html lang="en" class="dark min-h-dvh w-dvw scroll-pt-16 overflow-x-hidden">
+  // Function to apply a given theme by updating the class list of the document element
+  function applyTheme(theme) {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.documentElement.classList.toggle('light', theme === 'light');
+  }
+
+  // Initialize the theme when the page loads
+  const initialTheme = getPreferredTheme();
+  applyTheme(initialTheme);
+
+  // Update the theme automatically across all tabs when it's changed
+  window.addEventListener('storage', () => {
+    const updatedTheme = getPreferredTheme();
+    applyTheme(updatedTheme);
+  });
+</script>
+<html lang="en" class="min-h-dvh w-dvw scroll-pt-16 overflow-x-hidden">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,34 +5,8 @@ import '@styles/global.css';
 import '@styles/shad.css';
 
 const { description, title } = Astro.props;
-
 ---
-<script is:inline>
-  // Function to retrieve the user's theme preference from localStorage or system settings
-  function getPreferredTheme() {
-    const storedTheme = localStorage.getItem('themeToggle');
-    if (storedTheme) {
-      return storedTheme;
-    }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  }
 
-  // Function to apply a given theme by updating the class list of the document element
-  function applyTheme(theme) {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-    document.documentElement.classList.toggle('light', theme === 'light');
-  }
-
-  // Initialize the theme when the page loads
-  const initialTheme = getPreferredTheme();
-  applyTheme(initialTheme);
-
-  // Update the theme automatically across all tabs when it's changed
-  window.addEventListener('storage', () => {
-    const updatedTheme = getPreferredTheme();
-    applyTheme(updatedTheme);
-  });
-</script>
 <html lang="en" class="min-h-dvh w-dvw scroll-pt-16 overflow-x-hidden">
   <head>
     <meta charset="utf-8" />
@@ -42,8 +16,36 @@ const { description, title } = Astro.props;
     <meta name="description" content={description} />
     <title>{title}</title>
     <slot name="head" />
+    <script is:inline>
+      // Function to retrieve the user's theme preference from localStorage or system settings
+      function getPreferredTheme() {
+        const storedTheme = localStorage.getItem('themeToggle');
+        if (storedTheme) {
+          return storedTheme;
+        }
+        return window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light';
+      }
+
+      // Function to apply a given theme by updating the class list of the document element
+      function applyTheme(theme) {
+        document.documentElement.classList.toggle('dark', theme === 'dark');
+        document.documentElement.classList.toggle('light', theme === 'light');
+      }
+
+      // Initialize the theme when the page loads
+      const initialTheme = getPreferredTheme();
+      applyTheme(initialTheme);
+
+      // Update the theme automatically across all tabs when it's changed
+      window.addEventListener('storage', () => {
+        const updatedTheme = getPreferredTheme();
+        applyTheme(updatedTheme);
+      });
+    </script>
   </head>
-  <body class="flex flex-col items-center min-h-screen">
+  <body class="flex min-h-screen flex-col items-center">
     <NavBar />
     <main class="flex-grow">
       <slot />


### PR DESCRIPTION
Uses two scripts to initialize and apply theme in BaseLayout and add responsive toggle functionality in ThemeToggle.
This sets the theme immediately when the page loads, and allows the theme to be toggled between light and dark. This eliminated FOUC by loading the theme immediately in BaseLayout.

- **fix #19 first version**
- **Fix baselayout script placement**
