### PR TITLE
fix: improve keyboard navigation accessibility by resolving tabindex

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -35,9 +35,9 @@ const { ...attrs } = Astro.props;
     <div class="button-theme-container items-center flex gap-1">
       <div class="gap-1 text-[15px] sm:flex">
         <div class="hidden gap-1 sm:flex items-center">
-          <Button name="Home" link="/" />
-          <Button name="About" link="/about" />
-          <Button name="Blog" link="/blog" />
+          <Button name="Home" link="/" tabindex="-1" />
+          <Button name="About" link="/about" tabindex="-1" />
+          <Button name="Blog" link="/blog" tabindex="-1" />
           <DropdownMenu
             name="Projects"
             links={[

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -14,6 +14,7 @@ import { SideMenu } from '@components/SideMenu';
   <nav class="button-container flex w-full items-center justify-between pl-3">
     <a href="/">
       <Button
+        tabIndex={-1}
         variant="link"
         className="h-10 text-muted-dark hover:text-dark hover:no-underline dark:text-primary-400 dark:hover:text-muted-light/85">
         Home

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -37,6 +37,7 @@ export function SideMenu() {
               <span className="flex items-center" key={link.name}>
                 <a href={link.href} className='w-full'>
                   <Button
+                    tabIndex={-1}
                     variant="ghost"
                     size="lg"
                     className="h-9 w-full justify-start px-3 hover:no-underline">


### PR DESCRIPTION
buttons wrapped by links are not targeted twice when navigating with keyboard

- **fix tabindex on astro pages**
- **fix tabindex on react pages and components**
