### PR TITLE
Add `buttonStyles` prop to `CommandMenu`, use prop in `NavBar` to make button height shorter

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -15,8 +15,9 @@ import {
 import { Button } from '@/components/ui/button';
 
 import { mainLinks, projectLinks } from './SideMenu';
+import { cn } from '@/lib/utils';
 
-export function CommandMenu() {
+export function CommandMenu({ buttonStyles }: { buttonStyles?: string }) {
   const [open, setOpen] = React.useState(false);
 
   React.useEffect(() => {
@@ -48,9 +49,10 @@ export function CommandMenu() {
     <>
       <Button
         variant="outline"
-        className={
-          'relative hidden h-9 justify-between rounded-[0.5rem] bg-background pr-1.5 text-sm font-normal text-muted-foreground shadow-none sm:flex'
-        }
+        className={cn(
+          'relative hidden h-9 justify-between rounded-[0.5rem] bg-background pr-1.5 text-sm font-normal text-muted-foreground shadow-none sm:flex',
+          buttonStyles
+        )}
         style={{ width: 'clamp(120px, 20vw, 240px)' }}
         onClick={() => setOpen(true)}>
         <span className="inline-flex">Search...</span>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -29,7 +29,7 @@ const { ...attrs } = Astro.props;
           bassim
         </h1>
       </a>
-      <CommandMenu client:load />
+      <CommandMenu client:load buttonStyles='h-8 pr-1' />
     </span>
     <div class="button-theme-container flex items-center gap-1">
       <div class="gap-1 text-[15px] sm:flex">


### PR DESCRIPTION
Make button height `h-8` instead of `h-9` to fit better with `NavBar` UI