### PR TITLE
Update `CommandMenu` styling

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -20,25 +20,38 @@ import { cn } from '@/lib/utils';
 export function CommandMenu({ buttonStyles }: { buttonStyles?: string }) {
   const [open, setOpen] = React.useState(false);
 
-  React.useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      if (e.metaKey || e.ctrlKey) {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      setOpen((open) => !open);
+    } else if (e.key === '/') {
+      if (
+        !(
+          (e.target instanceof HTMLElement && e.target.isContentEditable) ||
+          e.target instanceof HTMLInputElement ||
+          e.target instanceof HTMLTextAreaElement ||
+          e.target instanceof HTMLSelectElement
+        )
+      ) {
         e.preventDefault();
-        if (e.key === 'k') {
-          setOpen((open) => !open);
-        } else {
-          const link = mainLinks.find((link) =>
-            link.shortcut.toLowerCase().endsWith(e.key.toLowerCase())
-          );
-          if (link) {
-            navigate(link.href);
-          }
-        }
+        setOpen((open) => !open);
       }
-    };
+    } else if (e.metaKey || e.ctrlKey) {
+      const link = mainLinks.find((link) =>
+        link.shortcut.toLowerCase().endsWith(e.key.toLowerCase())
+      );
+      if (link) {
+        e.preventDefault();
+        navigate(link.href);
+      }
+    }
+  };
 
-    document.addEventListener('keydown', down);
-    return () => document.removeEventListener('keydown', down);
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
   }, []);
 
   const navigate = (href: string) => {

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -74,10 +74,7 @@ export function CommandMenu({ buttonStyles }: { buttonStyles?: string }) {
         </kbd>
       </Button>
       <CommandDialog open={open} onOpenChange={setOpen}>
-        <CommandInput
-          className="placeholder:opacity-75"
-          placeholder="Type a command or search..."
-        />
+        <CommandInput placeholder="Type a command or search..." />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Suggestions">

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -74,7 +74,10 @@ export function CommandMenu({ buttonStyles }: { buttonStyles?: string }) {
         </kbd>
       </Button>
       <CommandDialog open={open} onOpenChange={setOpen}>
-        <CommandInput placeholder="Type a command or search..." />
+        <CommandInput
+          className="placeholder:opacity-75"
+          placeholder="Type a command or search..."
+        />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Suggestions">

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -116,7 +116,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled='true']:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled='true']:pointer-events-none data-[disabled='true']:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { type DialogProps } from "@radix-ui/react-dialog"
-import { MagnifyingGlassIcon } from "@radix-ui/react-icons"
+import { Terminal } from "lucide-react"
 import { Command as CommandPrimitive } from "cmdk"
 
 import { cn } from "@/lib/utils"
@@ -41,7 +41,7 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <MagnifyingGlassIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <Terminal className="mr-2 shrink-0 text-muted-foreground" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 backdrop-blur-[3px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}


### PR DESCRIPTION
- **Add data-[disabled='true'] to fix issue from https://github.com/shadcn-ui/ui/issues/2944#issuecomment-1985153126**
- **Update kbshortcut handling, allow '/' to open command dialog, but prevent it when focuses on a text, input, or select element**
- **Add 3px `backdrop-blur` when dialog is opened**
- **Use terminal icon in command search field instead of magnifying glass**
