### PR TITLE
List blog posts in `CommandMenu.tsx`, resolves BAS-22 

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { ArrowTopRightIcon } from '@radix-ui/react-icons';
+import { NotebookText } from 'lucide-react';
 
 import {
   CommandDialog,
@@ -17,7 +18,12 @@ import { Button } from '@/components/ui/button';
 import { mainLinks, projectLinks } from './SideMenu';
 import { cn } from '@/lib/utils';
 
-export function CommandMenu({ buttonStyles }: { buttonStyles?: string }) {
+type CommandMenuProps = {
+  buttonStyles?: string;
+  posts?: any[];
+};
+
+export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
   const [open, setOpen] = React.useState(false);
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -92,6 +98,20 @@ export function CommandMenu({ buttonStyles }: { buttonStyles?: string }) {
               <CommandItem key={index} onSelect={() => navigate(project.href)}>
                 <ArrowTopRightIcon className="mr-2 size-4" />
                 {project.name}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Blog Posts">
+            {posts?.map((post, index) => (
+              <CommandItem
+                slot="blogPosts"
+                key={index}
+                aria-label={`Link to blog post: ${post.frontmatter.title}`}
+                onSelect={() => navigate(post.url)}>
+                <NotebookText className="mr-2 size-4" />
+                {post.frontmatter.title}
+                <CommandShortcut>{post.frontmatter.pubDate}</CommandShortcut>
               </CommandItem>
             ))}
           </CommandGroup>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -6,6 +6,9 @@ import ThemeSwitcher from './ThemeSwitcher.astro';
 import { Icon } from 'astro-icon/components';
 import { CommandMenu } from '@components/CommandMenu';
 import { SideMenu } from '@components/SideMenu';
+
+const allPosts = await Astro.glob('@pages/posts/*.md');
+
 import type { HTMLAttributes } from 'astro/types';
 
 type Props = HTMLAttributes<'div'>;
@@ -24,12 +27,12 @@ const { ...attrs } = Astro.props;
     <span class="flex items-center">
       <a href="/" aria-label="home button" class="mr-4">
         <h1
-          class="logo flex items-center gap-x-2.5 text-xl font-bold text-foreground dark:text-muted-light h-9">
+          class="logo flex h-9 items-center gap-x-2.5 text-xl font-bold text-foreground dark:text-muted-light">
           <Icon name="shadlogo" size={20} />
           bassim
         </h1>
       </a>
-      <CommandMenu client:load buttonStyles='h-8 pr-1' />
+      <CommandMenu client:load buttonStyles="h-8 pr-1" posts={allPosts} />
     </span>
     <div class="button-theme-container flex items-center gap-1">
       <div class="gap-1 text-[15px] sm:flex">

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -6,7 +6,7 @@ import {
 } from '@components/ui/sheet';
 import { Button } from '@components/ui/button';
 import { HamburgerMenuIcon } from '@radix-ui/react-icons';
-import { HomeIcon, User, NotebookText } from 'lucide-react';
+import { HomeIcon, User, NotebookTabs } from 'lucide-react';
 
 export const mainLinks = [
   {
@@ -23,7 +23,7 @@ export const mainLinks = [
   },
   {
     name: 'Blog',
-    icon: <NotebookText className="mr-2 size-4" />,
+    icon: <NotebookTabs className="mr-2 size-4" />,
     href: '/blog',
     shortcut: '⌘B',
   },


### PR DESCRIPTION
Create posts prop to pass glob of blog posts to `CommandMenu.tsx` from the Astro file it's called in

Import `await Astro.glob` in `NavBar.astro,` pass to `posts` prop in `CommandMenu.tsx`

Update blog link icon in `SideMenu` and blog post icons in `CommandMenu`
