### PR TITLE
Refactor react `ModeToggle`, remove dropdown, fixes #128

### DIFF
--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -1,50 +1,28 @@
 import { Moon, Sun } from 'lucide-react';
-
 import { Button } from '@components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@components/ui/dropdown-menu';
 
 export function ModeToggle() {
-  const setTheme = (selectedTheme: 'light' | 'dark' | 'system') => {
-    const isDark =
-      selectedTheme === 'dark' ||
-      (selectedTheme === 'system' &&
-        window.matchMedia('(prefers-color-scheme: dark)').matches);
+  const toggleTheme = () => {
+    const currentTheme =
+      localStorage.getItem('themeToggle') ||
+      (window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light');
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
 
-    document.documentElement.classList.toggle('dark', isDark);
-
-    localStorage.setItem('theme', selectedTheme);
+    document.documentElement.classList.toggle('dark', newTheme === 'dark');
+    localStorage.setItem('themeToggle', newTheme);
   };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="icon"
-          className="focus-visible:bg-accent focus-visible:ring-transparent">
-          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Toggle theme</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className=''>
-        <DropdownMenuItem
-          onClick={() => setTheme('light')}
-          className="hover:bg-slate-500">
-          Light
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('dark')}>
-          Dark
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('system')}>
-          System
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={toggleTheme}
+      className="focus-visible:bg-accent focus-visible:ring-transparent">
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
   );
 }

--- a/src/layouts/ReactLayout.astro
+++ b/src/layouts/ReactLayout.astro
@@ -9,24 +9,20 @@ const { title, description } = Astro.props;
   <head>
     <Meta title={title} description={description} />
     <script is:inline>
-      const getThemePreference = () => {
-        return typeof localStorage !== 'undefined' &&
-          localStorage.getItem('theme')
-          ? localStorage.getItem('theme')
-          : window.matchMedia('(prefers-color-scheme: dark)').matches
-            ? 'dark'
-            : 'light';
-      };
+      const preferredTheme =
+        localStorage.getItem('themeToggle') ||
+        (window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light');
+      document.documentElement.classList.toggle(
+        'dark',
+        preferredTheme === 'dark'
+      );
 
-      const isDark = getThemePreference() === 'dark';
-      document.documentElement.classList.toggle('dark', isDark);
-
-      if (typeof localStorage !== 'undefined') {
-        window.addEventListener('storage', () => {
-          const isDark = document.documentElement.classList.contains('dark');
-          localStorage.setItem('theme', isDark ? 'dark' : 'light');
-        });
-      }
+      window.addEventListener('storage', () => {
+        const isDark = localStorage.getItem('themeToggle') === 'dark';
+        document.documentElement.classList.toggle('dark', isDark);
+      });
     </script>
   </head>
   <ReactHeader />


### PR DESCRIPTION
Use script from `BaseLayout` for intial theme setting based on system preference or local storage value
Make `ModeToggle` script closely match `ThemeToggle`, and remove the dropdown to make it a toggle button