### PR TITLE
Creat composable React `DropdownMenu` component, use for projects on react page

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -68,7 +68,7 @@ export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
         aria-label="Open command menu"
         variant="outline"
         className={cn(
-          'relative hidden h-9 justify-between rounded-[0.5rem] bg-background pr-1.5 text-sm font-normal text-muted-foreground shadow-none sm:flex',
+          'relative hidden h-9 justify-between rounded-[0.5rem] bg-background pr-1.5 text-sm font-normal text-muted-foreground shadow-none md:flex',
           buttonStyles
         )}
         style={{ width: 'clamp(120px, 20vw, 240px)' }}

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -13,7 +13,7 @@ export function Dropdown({ children }: { children: React.ReactNode }) {
       <DropdownMenuTrigger asChild>
         <Button
           variant="link"
-          className="hidden h-9 px-0 text-muted-foreground hover:text-foreground/80 hover:no-underline focus-visible:ring-0 data-[state='open']:text-foreground/80 sm:block">
+          className="hidden h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline data-[state='open']:text-foreground/80 sm:flex">
           {children}
         </Button>
       </DropdownMenuTrigger>

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -5,9 +5,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@components/ui/dropdown-menu';
-import { projectLinks } from './navLinks';
 
-export function Dropdown({ children }: { children: React.ReactNode }) {
+export function Dropdown({ children, items }: { children: React.ReactNode, items: {name: string, href: string}[] }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -18,13 +17,11 @@ export function Dropdown({ children }: { children: React.ReactNode }) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-24 min-w-fit">
-        {projectLinks.map((project) => (
-          <DropdownMenuItem
-            key={project.name}
-            className="text-muted-foreground">
-            <a href={project.href}>{project.name}</a>
+        {items.map((item) => (
+          <DropdownMenuItem key={item.name} className="text-muted-foreground">
+            <a href={item.href}>{item.name}</a>
           </DropdownMenuItem>
-        ))}{' '}
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@components/ui/dropdown-menu';
+import { projectLinks } from './navLinks';
+
+export function Dropdown({ children }: { children: React.ReactNode }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="link"
+          className="hidden h-9 px-0 text-muted-foreground hover:text-foreground/80 hover:no-underline focus-visible:ring-0 data-[state='open']:text-foreground/80 sm:block">
+          {children}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-24 min-w-fit">
+        {projectLinks.map((project) => (
+          <DropdownMenuItem
+            key={project.name}
+            className="text-muted-foreground">
+            <a href={project.href}>{project.name}</a>
+          </DropdownMenuItem>
+        ))}{' '}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -5,6 +5,7 @@ import { Icon } from 'astro-icon/components';
 import { SideMenu } from '@components/SideMenu';
 import { CommandMenu } from '@components/CommandMenu';
 import { mainLinks } from './navLinks';
+import { Dropdown } from '@components/DropdownMenu';
 
 const allPosts = await Astro.glob('@pages/posts/*.md');
 ---
@@ -34,6 +35,7 @@ const allPosts = await Astro.glob('@pages/posts/*.md');
           </a>
         ))
       }
+      <Dropdown client:load>Projects</Dropdown>
     </span>
     <span class="flex items-center gap-2">
       <CommandMenu client:load posts={allPosts} />

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -6,6 +6,7 @@ import { SideMenu } from '@components/SideMenu';
 import { CommandMenu } from '@components/CommandMenu';
 import { mainLinks } from './navLinks';
 import { Dropdown } from '@components/DropdownMenu';
+import { ChevronDown } from 'lucide-react';
 
 const allPosts = await Astro.glob('@pages/posts/*.md');
 ---
@@ -19,23 +20,26 @@ const allPosts = await Astro.glob('@pages/posts/*.md');
     </h1>
   </a>
   <nav class="button-container flex w-full items-center justify-between pl-3">
-    <span class="flex gap-5 px-4">
+    <span class="flex gap-2 px-4">
       {
         mainLinks.map((link, index) => (
-          <a href={link.href}>
+          <a href={link.href} class="rounded-md">
             <Button
               client:load
               aria-label={link.name}
               key={index}
               tabIndex={-1}
               variant="link"
-              className="hidden h-9 px-0 text-muted-foreground hover:text-foreground/80 hover:no-underline sm:block">
+              className="hidden h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline sm:block">
               {link.name}
             </Button>
           </a>
         ))
       }
-      <Dropdown client:load>Projects</Dropdown>
+      <Dropdown client:load>
+        Projects
+        <ChevronDown size={12} className="ml-1.5" />
+      </Dropdown>
     </span>
     <span class="flex items-center gap-2">
       <CommandMenu client:load posts={allPosts} />

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -7,6 +7,7 @@ import { CommandMenu } from '@components/CommandMenu';
 import { mainLinks } from './navLinks';
 import { Dropdown } from '@components/DropdownMenu';
 import { ChevronDown } from 'lucide-react';
+import { projectLinks } from './navLinks';
 
 const allPosts = await Astro.glob('@pages/posts/*.md');
 ---
@@ -36,7 +37,7 @@ const allPosts = await Astro.glob('@pages/posts/*.md');
           </a>
         ))
       }
-      <Dropdown client:load>
+      <Dropdown client:load items={projectLinks}>
         Projects
         <ChevronDown size={12} className="ml-1.5" />
       </Dropdown>


### PR DESCRIPTION
fixes #159 
- **Create shadcn-ui dropdown menu component, import in `ReactHeader`**
- **Add chevron icon, update nav button and dropdown trigger padding**
- **Make `DropdownMenu` composable with `items` prop, pass `projectLinks` array in `ReactHeader`**
- **Hide `CommandMenu` search button under `md` instead of `sm`**
