### PR TITLE
Update Dropdown button and icon CSS

### DIFF
--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -11,14 +11,16 @@ export function Dropdown({ children, items }: { children: React.ReactNode, items
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          variant="link"
-          className="group hidden h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline data-[state='open']:text-foreground/80 sm:flex">
+          variant="ghost"
+          className="data-[state='open']:bg-accent group hidden h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline data-[state='open']:text-foreground/80 sm:flex">
           {children}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-24 min-w-fit">
         {items.map((item) => (
-          <DropdownMenuItem key={item.name} className="text-muted-foreground py-2">
+          <DropdownMenuItem
+            key={item.name}
+            className="py-2 text-muted-foreground">
             <a href={item.href}>{item.name}</a>
           </DropdownMenuItem>
         ))}

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -39,7 +39,7 @@ const allPosts = await Astro.glob('@pages/posts/*.md');
       }
       <Dropdown client:load items={projectLinks}>
         Projects
-        <ChevronDown size={12} className="ml-1.5 group-data-[state='open']:rotate-180 transition-all" />
+        <ChevronDown size={12} className="ml-1.5 mt-[1px] group-data-[state='open']:rotate-180 transition-all" />
       </Dropdown>
     </span>
     <span class="flex items-center gap-2">


### PR DESCRIPTION
### TL;DR

In `DropdownMenu` make Dropdown button ghost style, set `bg-accent` when dropdown open
Add `margin-top` to chevron icon in `ReactHeader`

### What changed?

In `DropdownMenu.tsx`, the button variant has been updated from 'link' to 'ghost' and `bg-accent` added when dropdown data state is open. 

In `ReactHeader`, added `margin-top`  to icon so it appears more symmetrical with button.