### PR TITLE
Create separate component for logo, adjust styling

### DIFF
--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,0 +1,17 @@
+---
+import { Icon } from 'astro-icon/components';
+
+const { class: className } = Astro.props;
+
+interface Props {
+  class?: string;
+}
+---
+
+<a href="/" aria-label="home button" class={className}>
+  <h1
+    class="logo flex h-9 items-center gap-x-2.5 text-xl font-bold text-foreground dark:text-muted-light">
+    <Icon name="shadlogo" size={20} />
+    bassim
+  </h1>
+</a>

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -8,10 +8,10 @@ interface Props {
 }
 ---
 
-<a href="/" aria-label="home button" class={className}>
-  <h1
-    class="logo flex h-9 items-center gap-x-2.5 text-xl font-bold text-foreground dark:text-muted-light">
+<a href="/" aria-label="logo, link to homepage" class={className}>
+  <span
+    class="logo flex h-9 items-center pb-0.5 gap-x-2.5 text-xl font-bold text-foreground dark:text-muted-light">
     <Icon name="shadlogo" size={20} />
     bassim
-  </h1>
+  </span>
 </a>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -3,9 +3,9 @@ import Button from './Button.astro';
 import DropdownMenu from './DropdownMenu.astro';
 import ThemeToggle from './ThemeToggle.astro';
 import ThemeSwitcher from './ThemeSwitcher.astro';
-import { Icon } from 'astro-icon/components';
 import { CommandMenu } from '@components/CommandMenu';
 import { SideMenu } from '@components/SideMenu';
+import Logo from './Logo.astro';
 
 const allPosts = await Astro.glob('@pages/posts/*.md');
 
@@ -25,13 +25,7 @@ const { ...attrs } = Astro.props;
   <div
     class="button-container flex items-center justify-between px-4 py-2 text-dark dark:text-light sm:px-6 md:px-10 xl:px-14">
     <span class="flex items-center">
-      <a href="/" aria-label="home button" class="mr-4">
-        <h1
-          class="logo flex h-9 items-center gap-x-2.5 text-xl font-bold text-foreground dark:text-muted-light">
-          <Icon name="shadlogo" size={20} />
-          bassim
-        </h1>
-      </a>
+      <Logo class='mr-4' />
       <CommandMenu client:load buttonStyles="h-8 pr-1" posts={allPosts} />
     </span>
     <div class="button-theme-container flex items-center gap-1">

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -1,26 +1,20 @@
 ---
 import { Button } from '@components/ui/button';
 import { ModeToggle } from '@components/ModeToggle';
-import { Icon } from 'astro-icon/components';
 import { SideMenu } from '@components/SideMenu';
 import { CommandMenu } from '@components/CommandMenu';
 import { mainLinks } from './navLinks';
 import { Dropdown } from '@components/DropdownMenu';
 import { ChevronDown } from 'lucide-react';
 import { projectLinks } from './navLinks';
+import Logo from './Logo.astro';
 
 const allPosts = await Astro.glob('@pages/posts/*.md');
 ---
 
 <header class="flex items-center border-b border-border/50 px-8 py-2">
-  <a href="/">
-    <h1
-      class="flex items-center gap-x-2.5 text-xl font-bold text-foreground dark:text-muted-light">
-      <Icon name="shadlogo" size={20} />
-      bassim
-    </h1>
-  </a>
-  <nav class="button-container flex w-full items-center justify-between ml-2">
+  <Logo />
+  <nav class="button-container ml-2 flex w-full items-center justify-between">
     <span class="flex gap-2 px-4">
       {
         mainLinks.map((link, index) => (
@@ -39,7 +33,10 @@ const allPosts = await Astro.glob('@pages/posts/*.md');
       }
       <Dropdown client:load items={projectLinks}>
         Projects
-        <ChevronDown size={12} className="ml-1.5 mt-[1.5px] group-data-[state='open']:rotate-180 transition-all" />
+        <ChevronDown
+          size={12}
+          className="ml-1.5 mt-[1.5px] transition-all group-data-[state='open']:rotate-180"
+        />
       </Dropdown>
     </span>
     <span class="flex items-center gap-2">


### PR DESCRIPTION
closes #137 
- Create `Logo` component for Bassim logo, use in `ReactHeader` and `NavBar`
- update aria label, use span instead of h1, add pb-0.5 to appear more centered
