### PR TITLE
Add condition in `Button.astro` to highlight links based on active page

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,5 +1,6 @@
 ---
 import { Icon } from 'astro-icon/components';
+import { cn } from '@/lib/utils';
 import type { HTMLAttributes } from 'astro/types';
 
 interface Props extends HTMLAttributes<'button'> {
@@ -22,6 +23,8 @@ const {
   icon = false,
   ...attrs
 } = Astro.props;
+
+const currentPath = new URL(Astro.request.url).pathname;
 
 const baseStyles: string = `items-center border border-transparent flex max-w-max rounded-lg font-normal text-foreground/70 hover:text-foreground`;
 
@@ -53,7 +56,14 @@ const variableStyles: (string | undefined)[] = [
     <a href={link} id={id}>
       <button
         {...attrs}
-        class:list={[baseStyles, variableStyles]}
+        class={cn(
+          baseStyles,
+          variableStyles,
+          currentPath === link ||
+            (link === '/blog' && currentPath.includes('/posts/'))
+            ? 'text-foreground'
+            : ''
+        )}
         aria-label={`${name} button`}>
         {icon ? <Icon name={name} size={26} /> : name}
         {showCaret && (

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -60,7 +60,8 @@ const variableStyles: (string | undefined)[] = [
           baseStyles,
           variableStyles,
           currentPath === link ||
-            (link === '/blog' && currentPath.includes('/posts/'))
+            currentPath === `${link}/` ||
+            (link === '/blog' && currentPath.startsWith('/posts/'))
             ? 'text-foreground'
             : ''
         )}


### PR DESCRIPTION
Uses Astro's rntime API to get the current page path and apply `text-foreground` with `cn()` to the correct button if the path matches the button's href, defined as 'link' in `NavBar.astro`