### PR TITLE
Use href for `DropdownMenu.astro` links

### DIFF
--- a/src/components/DropdownMenu.astro
+++ b/src/components/DropdownMenu.astro
@@ -4,7 +4,7 @@ import Button from './Button.astro';
 
 interface Link {
   name: string;
-  url: string;
+  href: string;
 }
 
 interface Props extends HTMLAttributes<'div'> {
@@ -40,7 +40,7 @@ const {
     {
       links.map((link) => (
         <a
-          href={link.url}
+          href={link.href}
           class="m-1 block rounded-sm px-2 py-2 text-sm text-foreground/75 transition-colors duration-200 hover:bg-primary-200/70 hover:text-foreground dark:hover:bg-accent">
           {link.name}
         </a>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -37,12 +37,7 @@ const { ...attrs } = Astro.props;
           <Button name="Blog" link="/blog" tabindex="-1" />
           <DropdownMenu
             name="Projects"
-            links={[
-              { name: 'Minimal Typography', href: '/designProject' },
-              { name: 'Old Flask Site', href: '/flaskSite' },
-              { name: 'GPT Chat', href: '/gpt' },
-              { name: 'React + shadcn/ui', href: '/react' },
-            ]}
+            links={projectLinks}
             showCaret={true}
             icon={false}
           />

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -6,6 +6,7 @@ import ThemeSwitcher from './ThemeSwitcher.astro';
 import { CommandMenu } from '@components/CommandMenu';
 import { SideMenu } from '@components/SideMenu';
 import Logo from './Logo.astro';
+import { projectLinks } from './navLinks';
 
 const allPosts = await Astro.glob('@pages/posts/*.md');
 
@@ -37,10 +38,10 @@ const { ...attrs } = Astro.props;
           <DropdownMenu
             name="Projects"
             links={[
-              { name: 'Minimal Typography', url: '/designProject' },
-              { name: 'Old Flask Site', url: '/flaskSite' },
-              { name: 'GPT Chat', url: '/gpt' },
-              { name: 'React + shadcn/ui', url: '/react' },
+              { name: 'Minimal Typography', href: '/designProject' },
+              { name: 'Old Flask Site', href: '/flaskSite' },
+              { name: 'GPT Chat', href: '/gpt' },
+              { name: 'React + shadcn/ui', href: '/react' },
             ]}
             showCaret={true}
             icon={false}

--- a/src/components/ThemeSwitcher.astro
+++ b/src/components/ThemeSwitcher.astro
@@ -5,13 +5,13 @@ import type { HTMLAttributes } from 'astro/types';
 type Props = HTMLAttributes<'div'>;
 
 const themeOptions = [
-  { name: 'Sky', url: '#sky' },
-  { name: 'Cyan', url: '#cyan' },
-  { name: 'Teal', url: '#teal' },
-  { name: 'Emerald', url: '#emerald' },
-  { name: 'Violet', url: '#violet' },
-  { name: 'Fuchsia', url: '#fuchsia' },
-  { name: 'Amber', url: '#amber' },
+  { name: 'Sky', href: '#sky' },
+  { name: 'Cyan', href: '#cyan' },
+  { name: 'Teal', href: '#teal' },
+  { name: 'Emerald', href: '#emerald' },
+  { name: 'Violet', href: '#violet' },
+  { name: 'Fuchsia', href: '#fuchsia' },
+  { name: 'Amber', href: '#amber' },
 ];
 ---
 


### PR DESCRIPTION
closes #198 

Use href for `DropdownMenu.astro` links

This makes link array behavior consistent with `navLinks.tsx`, `SideMenu.tsx` and `DropdownMenu.tsx`

Use `projectLinks` array for projects menu in `NavBar.astro`

Instead of hardcoding project links in `NavBar.astro`