### PR TITLE
Change dropdown menu width, remove `w-24`

### DIFF
--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -46,7 +46,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
           {children}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-24 min-w-fit" align="center">
+      <DropdownMenuContent className="min-w-fit" align="center">
         {items.map((item) => (
           <DropdownMenuItem
             key={item.name}


### PR DESCRIPTION
This allows `AccentColorSelector` menu to be as small as it's content
This affects the Projects Dropdown in `ReactHeader`, it's menu is wider and no longer causing text to wrap