### PR TITLE
Remove hidden class from `DropdownMenu`, hide buttons in `ReactHeader`

### DIFF
--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -42,7 +42,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
       <DropdownMenuTrigger asChild>
         <Button
           variant={variant}
-          className="group hidden h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline data-[state='open']:bg-accent data-[state='open']:text-foreground/80 sm:flex">
+          className="group flex h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline data-[state='open']:bg-accent data-[state='open']:text-foreground/80">
           {children}
         </Button>
       </DropdownMenuTrigger>

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -15,7 +15,7 @@ const allPosts = await Astro.glob('@pages/posts/*.md');
 
 <header class="flex w-full items-center border-b border-border/50 px-8 py-2">
   <Logo />
-  <nav class="button-container ml-2 flex w-full items-center justify-between">
+  <div class="button-container ml-2 flex w-full items-center justify-between">
     <nav>
       <span class="hidden gap-2 px-4 sm:flex">
         {
@@ -48,5 +48,5 @@ const allPosts = await Astro.glob('@pages/posts/*.md');
       <SideMenu client:load />
       <ModeToggle client:load />
     </span>
-  </nav>
+  </div>
 </header>

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -13,33 +13,35 @@ import { AccentColorSelector } from './AccentColorSelector';
 const allPosts = await Astro.glob('@pages/posts/*.md');
 ---
 
-<header class="flex items-center w-full border-b border-border/50 px-8 py-2">
+<header class="flex w-full items-center border-b border-border/50 px-8 py-2">
   <Logo />
   <nav class="button-container ml-2 flex w-full items-center justify-between">
-    <span class="flex gap-2 px-4">
-      {
-        mainLinks.map((link, index) => (
-          <a href={link.href} class="rounded-md">
-            <Button
-              client:load
-              aria-label={link.name}
-              key={index}
-              tabIndex={-1}
-              variant="link"
-              className="hidden h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline sm:block">
-              {link.name}
-            </Button>
-          </a>
-        ))
-      }
-      <Dropdown client:load items={projectLinks} variant="link"> 
-        Projects
-        <ChevronDown
-          size={12}
-          className="ml-1.5 mt-[1.5px] transition-all group-data-[state='open']:rotate-180"
-        />
-      </Dropdown>
-    </span>
+    <nav>
+      <span class="hidden gap-2 px-4 sm:flex">
+        {
+          mainLinks.map((link, index) => (
+            <a href={link.href} class="rounded-md">
+              <Button
+                client:load
+                aria-label={link.name}
+                key={index}
+                tabIndex={-1}
+                variant="link"
+                className="h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline">
+                {link.name}
+              </Button>
+            </a>
+          ))
+        }
+        <Dropdown client:load items={projectLinks} variant="link">
+          Projects
+          <ChevronDown
+            size={12}
+            className="ml-1.5 mt-[1.5px] transition-all group-data-[state='open']:rotate-180"
+          />
+        </Dropdown>
+      </span>
+    </nav>
     <span class="flex items-center gap-2">
       <CommandMenu client:load posts={allPosts} />
       <AccentColorSelector client:load />


### PR DESCRIPTION
Remove hidden class from `DropdownMenu`, hide buttons in `ReactHeader`

This makes the `DropdownMenu` more composable and enables `AccentColorSelector` to remain shown at smaller breakpoints.

Change wrapping  to a div