### PR TITLE
Use local storage to store and set the accent color

### DIFF
--- a/src/components/AccentColorSelector.tsx
+++ b/src/components/AccentColorSelector.tsx
@@ -12,10 +12,18 @@ const themeOptions = [
 ];
 
 export const AccentColorSelector: React.FC = () => {
-  const [selectedTheme, setSelectedTheme] = useState('sky');
+  const [selectedTheme, setSelectedTheme] = useState(() => {
+    const storedTheme =
+      typeof window !== 'undefined' &&
+      window.localStorage?.getItem('themeSwitcher');
+    return storedTheme || 'sky';
+  });
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', selectedTheme);
+    if (typeof window !== 'undefined' && window.localStorage) {
+      document.documentElement.setAttribute('data-theme', selectedTheme);
+      localStorage.setItem('themeSwitcher', selectedTheme);
+    }
   }, [selectedTheme]);
 
   const handleThemeChange = (href: string) => {


### PR DESCRIPTION
Allows color selection to persist across page loads and other parts of the app.