### PR TITLE
Add `ariaLabel` prop to `Dropdown` component

### DIFF
--- a/src/components/AccentColorSelector.tsx
+++ b/src/components/AccentColorSelector.tsx
@@ -34,6 +34,7 @@ export const AccentColorSelector: React.FC = () => {
   return (
     <Dropdown
       items={themeOptions}
+      ariaLabel="Open accent color selector menu"
       variant="outline"
       onSelect={handleThemeChange}>
       <div className="flex items-center">

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -12,6 +12,7 @@ type DropdownProps = {
   items: { name: string; href: string }[];
   children: React.ReactNode;
   onSelect?: (href: string) => void;
+  ariaLabel?: string;
   variant?:
     | 'ghost'
     | 'link'
@@ -28,6 +29,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
   items,
   variant,
   onSelect,
+  ariaLabel,
 }) => {
   const handleSelect = (href: string) => {
     if (onSelect) {
@@ -42,6 +44,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
       <DropdownMenuTrigger asChild>
         <Button
           variant={variant}
+          aria-label={ariaLabel}
           className="group flex h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline data-[state='open']:bg-accent data-[state='open']:text-foreground/80">
           {children}
         </Button>

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -33,7 +33,11 @@ const allPosts = await Astro.glob('@pages/posts/*.md');
             </a>
           ))
         }
-        <Dropdown client:load items={projectLinks} variant="link">
+        <Dropdown
+          client:load
+          items={projectLinks}
+          ariaLabel="Open projects dropdown menu"
+          variant="link">
           Projects
           <ChevronDown
             size={12}


### PR DESCRIPTION
stack closes #146

Add `ariaLabel` prop to `Dropdown` component

Allows `ariaLabel` to be set when using `Dropdown` component. `ariaLabel` is passed to the `Button` component within `DropdownMenuTrigger`.

Set aria label in `AccentColorSelector` and `ReactHeader`