### PR TITLE
Update AccentColorSelector logic

### DIFF
--- a/src/components/AccentColorSelector.tsx
+++ b/src/components/AccentColorSelector.tsx
@@ -20,15 +20,26 @@ export const AccentColorSelector: React.FC = () => {
   });
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      document.documentElement.setAttribute('data-theme', selectedTheme);
-      localStorage.setItem('themeSwitcher', selectedTheme);
-    }
-  }, [selectedTheme]);
+    const handleStorageChange = () => {
+      const storedTheme = localStorage.getItem('themeSwitcher');
+      const localStorageAccessible =
+        typeof window !== 'undefined' && window.localStorage;
+
+      if (localStorageAccessible && storedTheme !== selectedTheme) {
+        setSelectedTheme(storedTheme);
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+
+    return () => window.removeEventListener('storage', handleStorageChange);
+  }, []);
 
   const handleThemeChange = (href: string) => {
     const theme = href.substring(1);
     setSelectedTheme(theme);
+    localStorage.setItem('themeSwitcher', theme);
+    document.documentElement.setAttribute('data-theme', theme);
   };
 
   return (

--- a/src/layouts/ReactLayout.astro
+++ b/src/layouts/ReactLayout.astro
@@ -9,6 +9,11 @@ const { title, description } = Astro.props;
   <head>
     <Meta title={title} description={description} />
     <script is:inline>
+      const storedTheme = localStorage.getItem('themeSwitcher');
+      const theme = storedTheme || 'sky';
+      document.documentElement.setAttribute('data-theme', theme);
+    </script>
+    <script is:inline>
       const preferredTheme =
         localStorage.getItem('themeToggle') ||
         (window.matchMedia('(prefers-color-scheme: dark)').matches


### PR DESCRIPTION
- **Set accent color theme in ReactLayout to prevent FOUC**
- **Update `AccentColorSelector` script**
  - Add `handleStorageChange` function to set localstorage value after it sets theme state
  -  Add event listener to localstorage and set theme when it changes and if its not already been set by `handleThemeChange` function
  -  Extract `typeof window !== 'undefined' && window.localStorage` to a variable called `localStorageAccessible` to make code clearer and cleaner
