### PR TITLE
Remove DropdownMenuItem, items prop, and map from DropdownMenu.tsx

### DIFF
--- a/src/components/AccentColorSelector.tsx
+++ b/src/components/AccentColorSelector.tsx
@@ -7,61 +7,16 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@components/ui/tooltip';
-
-interface ThemeOptionItemProps {
-  className: string;
-  colorName: string;
-}
-
-const ThemeOptionItem: React.FC<ThemeOptionItemProps> = ({
-  className,
-  colorName,
-}) => {
-  return (
-    <Tooltip delayDuration={250}>
-      <TooltipTrigger asChild>
-        <div className={`${className} size-5 rounded-full`} />
-      </TooltipTrigger>
-      <TooltipContent
-        side="left"
-        sideOffset="1"
-        className="bg-muted text-foreground">
-        {colorName}
-        <Arrow className="fill-muted" width={12} height={6} />
-      </TooltipContent>
-    </Tooltip>
-  );
-};
+import { DropdownMenuItem } from '@components/ui/dropdown-menu';
 
 const themeOptions = [
-  {
-    name: <ThemeOptionItem className="bg-sky-400" colorName="Sky" />,
-    href: '#sky',
-  },
-  {
-    name: <ThemeOptionItem className="bg-cyan-400" colorName="Cyan" />,
-    href: '#cyan',
-  },
-  {
-    name: <ThemeOptionItem className="bg-teal-400" colorName="Teal" />,
-    href: '#teal',
-  },
-  {
-    name: <ThemeOptionItem className="bg-emerald-400" colorName="Emerald" />,
-    href: '#emerald',
-  },
-  {
-    name: <ThemeOptionItem className="bg-violet-400" colorName="Violet" />,
-    href: '#violet',
-  },
-  {
-    name: <ThemeOptionItem className="bg-fuchsia-400" colorName="Fuchsia" />,
-    href: '#fuchsia',
-  },
-  {
-    name: <ThemeOptionItem className="bg-amber-400" colorName="Amber" />,
-    href: '#amber',
-  },
+  { colorName: 'Sky', colorClass: 'bg-sky-400', href: '#sky' },
+  { colorName: 'Cyan', colorClass: 'bg-cyan-400', href: '#cyan' },
+  { colorName: 'Teal', colorClass: 'bg-teal-400', href: '#teal' },
+  { colorName: 'Emerald', colorClass: 'bg-emerald-400', href: '#emerald' },
+  { colorName: 'Violet', colorClass: 'bg-violet-400', href: '#violet' },
+  { colorName: 'Fuchsia', colorClass: 'bg-fuchsia-400', href: '#fuchsia' },
+  { colorName: 'Amber', colorClass: 'bg-amber-400', href: '#amber' },
 ];
 
 export const AccentColorSelector: React.FC = () => {
@@ -102,14 +57,31 @@ export const AccentColorSelector: React.FC = () => {
 
   return (
     <TooltipProvider>
-      <Dropdown
-        items={themeOptions}
-        ariaLabel="Open accent color selector menu"
-        variant="outline"
-        onSelect={handleThemeChange}>
+      <Dropdown ariaLabel="Open accent color selector menu" variant="outline">
         <div className="flex items-center">
           <div className="size-5 rounded-full bg-accent-400" />
         </div>
+        {themeOptions.map((option) => (
+          <Tooltip key={option.href} delayDuration={250}>
+            <TooltipTrigger asChild>
+              <DropdownMenuItem
+                className="py-2 text-muted-foreground"
+                onSelect={() => handleThemeChange(option.href)}>
+                <div className="flex items-center space-x-2">
+                  <div className={`${option.colorClass} size-5 rounded-full`} />
+                  <span className="sr-only">{option.colorName}</span>
+                </div>
+              </DropdownMenuItem>
+            </TooltipTrigger>
+            <TooltipContent
+              side="left"
+              sideOffset="0"
+              className="bg-muted text-foreground">
+              {option.colorName}
+              <Arrow className="fill-muted" width={12} height={6} />
+            </TooltipContent>
+          </Tooltip>
+        ))}
       </Dropdown>
     </TooltipProvider>
   );

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
-
 import { Button } from '@components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@components/ui/dropdown-menu';
 
 type DropdownProps = {
-  items: { name: string; href: string }[];
-  children: React.ReactNode;
-  onSelect?: (href: string) => void;
+  children: [React.ReactNode, React.ReactNode];
   ariaLabel?: string;
   variant?:
     | 'ghost'
@@ -26,18 +22,11 @@ type DropdownProps = {
 
 export const Dropdown: React.FC<DropdownProps> = ({
   children,
-  items,
   variant,
-  onSelect,
   ariaLabel,
 }) => {
-  const handleSelect = (href: string) => {
-    if (onSelect) {
-      onSelect(href);
-    } else {
-      window.location.href = href;
-    }
-  };
+  
+  const [triggerChild, dropdownItem] = children;
 
   return (
     <DropdownMenu>
@@ -46,18 +35,11 @@ export const Dropdown: React.FC<DropdownProps> = ({
           variant={variant}
           aria-label={ariaLabel}
           className="group flex h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline data-[state='open']:bg-accent data-[state='open']:text-foreground/80">
-          {children}
+          {triggerChild}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="min-w-fit" align="center">
-        {items.map((item, index) => (
-          <DropdownMenuItem
-            key={index + 1}
-            className="py-2 text-muted-foreground"
-            onSelect={() => handleSelect(item.href)}>
-            {item.name}
-          </DropdownMenuItem>
-        ))}
+        {dropdownItem}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/ProjectsDropdown.tsx
+++ b/src/components/ProjectsDropdown.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Dropdown } from '@components/DropdownMenu';
+import { ChevronDown } from 'lucide-react';
+import { DropdownMenuItem } from '@components/ui/dropdown-menu';
+import { projectLinks } from './navLinks';
+
+
+export const ProjectsDropdown: React.FC = () => {
+  return (
+    <Dropdown variant="link" ariaLabel="Open projects dropdown menu">
+      <span className="flex items-center">
+        Projects
+        <ChevronDown
+          size={12}
+          className="ml-1.5 mt-[1.5px] transition-all group-data-[state=open]:rotate-180"
+        />
+      </span>
+      {projectLinks.map((link) => (
+        <DropdownMenuItem
+          key={link.href}
+          className="py-2 text-muted-foreground"
+          onSelect={() => {
+            window.location.href = link.href;
+          }}>
+          {link.name}
+        </DropdownMenuItem>
+      ))}
+    </Dropdown>
+  );
+};

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -4,16 +4,15 @@ import { ModeToggle } from '@components/ModeToggle';
 import { SideMenu } from '@components/SideMenu';
 import { CommandMenu } from '@components/CommandMenu';
 import { mainLinks } from './navLinks';
-import { Dropdown } from '@components/DropdownMenu';
-import { ChevronDown } from 'lucide-react';
-import { projectLinks } from './navLinks';
 import Logo from './Logo.astro';
 import { AccentColorSelector } from './AccentColorSelector';
+import { ProjectsDropdown } from './ProjectsDropdown';
 
 const allPosts = await Astro.glob('@pages/posts/*.md');
 ---
 
-<header class="flex w-full items-center border-b border-border/50 px-[clamp(0.75rem,3vw,2.5rem)] py-2"> 
+<header
+  class="flex w-full items-center border-b border-border/50 px-[clamp(0.75rem,3vw,2.5rem)] py-2">
   <Logo />
   <div class="button-container ml-2 flex w-full items-center justify-between">
     <nav>
@@ -33,17 +32,7 @@ const allPosts = await Astro.glob('@pages/posts/*.md');
             </a>
           ))
         }
-        <Dropdown
-          client:load
-          items={projectLinks}
-          ariaLabel="Open projects dropdown menu"
-          variant="link">
-          Projects
-          <ChevronDown
-            size={12}
-            className="ml-1.5 mt-[1.5px] transition-all group-data-[state='open']:rotate-180"
-          />
-        </Dropdown>
+        <ProjectsDropdown client:load />
       </span>
     </nav>
     <span class="flex items-center gap-2">


### PR DESCRIPTION
Closes BAS-80

Remove DropdownMenuItem, items prop, and map from DropdownMenu.tsx

Use DropdownMenuItem as a child of DropdownMenu and map over array to render items from within the component calling DropdownMenu
This makes the DropdownMenu component more reusable and composable
Specifically define triggerChild and dropdownItem as children of DropdownMenu so both can be defined as needed when called

Update `AccentColorSelector` to use `DropdownMenuItem` and map over array directly

Update themeOptions array removing color icon div
Map over themeOptions array to create each `DropdownMenuItem` and child color icon div directly within `AccentColorSelector`
Wrap Dropdown with `TooltipProvider`, wrap `DropdownContent` with `Tootip` and use each `dropdownmenuitem` tooltip triggers

Create `ProjectsDropdown` component

Directly map over `projectLinks` array to create dropdown items.

Use Projects text and `ChevronDown` icon within a span as the dropdown trigger.

Import in `ReactHeader`