### PR TITLE
refactor(SideMenu): Use navLinks components built with shadcn navigation-menu

### DIFF
--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -66,7 +66,7 @@ const ProjectNavButtons: React.FC = () => {
   );
 };
 
-export function SideMenu() {
+export const SideMenu: React.FC = () => {
   return (
     <Sheet>
       <SheetTrigger asChild>

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -5,11 +5,66 @@ import {
   SheetContent,
   SheetTitle,
   SheetTrigger,
-} from '@components/ui/sheet';
-import { Button } from '@components/ui/button';
+} from './ui/sheet';
 
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuLink,
+} from './ui/navigation-menu';
+
+import { Button } from './ui/button';
 import { HamburgerMenuIcon } from '@radix-ui/react-icons';
 import { mainLinks, projectLinks, iconStyles } from './navLinks';
+
+const MainNavButtons: React.FC = () => {
+  return (
+    <NavigationMenu
+      orientation="vertical"
+      className="min-w-full [&>div]:w-full">
+      <NavigationMenuList className="flex w-full flex-col items-start justify-start space-x-0">
+        {mainLinks.map((link) => (
+          <NavigationMenuItem key={link.name} className="w-full">
+            <NavigationMenuLink href={link.href} className="">
+              <Button variant="ghost" className="h-9 w-full justify-start px-3">
+                {React.createElement(link.icon, {
+                  className: iconStyles,
+                })}
+                {link.name}
+              </Button>
+            </NavigationMenuLink>
+          </NavigationMenuItem>
+        ))}
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
+};
+
+const ProjectNavButtons: React.FC = () => {
+  return (
+    <NavigationMenu
+      orientation="vertical"
+      className="min-w-full [&>div]:w-full">
+      <NavigationMenuList className="flex w-full flex-col items-start justify-start space-x-0">
+        {projectLinks.map((project) => (
+          <NavigationMenuItem key={project.name} className="w-full">
+            <NavigationMenuLink href={project.href} className="">
+              <Button
+                tabIndex={-1}
+                variant="link"
+                size="lg"
+                className="h-8 w-full justify-start px-3 text-muted-foreground hover:text-foreground hover:no-underline">
+                {project.name}
+              </Button>
+            </NavigationMenuLink>
+          </NavigationMenuItem>
+        ))}
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
+};
 
 export function SideMenu() {
   return (
@@ -21,42 +76,16 @@ export function SideMenu() {
       </SheetTrigger>
       <SheetContent side="left" className="w-64 overflow-y-auto">
         <SheetTitle className="font-bold">bassim</SheetTitle>
-        <nav className="mt-4 flex flex-col">
+        <div className="mt-4 flex flex-col">
           <section>
-            {mainLinks.map((link) => (
-              <span className="flex items-center" key={link.name}>
-                <a href={link.href} className="w-full">
-                  <Button
-                    tabIndex={-1}
-                    variant="ghost"
-                    size="lg"
-                    className="h-9 w-full justify-start px-3 hover:no-underline">
-                    {React.createElement(link.icon, {
-                      className: iconStyles,
-                    })}
-                    {link.name}
-                  </Button>
-                </a>
-              </span>
-            ))}
+            <MainNavButtons />
           </section>
           <hr className="my-4" />
           <section>
             <h4 className="mb-2 ml-2 mt-1 font-semibold">Projects</h4>
-            <span className="flex flex-col items-start [&_a]:my-1.5 [&_a]:h-full [&_a]:px-4">
-              {projectLinks.map((project) => (
-                <Button
-                  asChild
-                  variant="link"
-                  size="lg"
-                  className="w-full justify-start text-muted-foreground hover:text-foreground hover:no-underline"
-                  key={project.name}>
-                  <a href={project.href}>{project.name}</a>
-                </Button>
-              ))}
-            </span>
+            <ProjectNavButtons />
           </section>
-        </nav>
+        </div>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
**Use navLinks components built with shadcn navigation-menu**

- Replace original `SideMenu` button lists with shadcn navigation menu components which map over navLinks arrays to render buttons.

This adds keyboard navigation and improves accessibility, while maintaining the same visual appearance.

---
- **Use relative imports for components in `SideMenu`**
- **Use `const SideMenu: React.FC` instead of `function SideMenu()`**

These changes maintain consistency with other components within this project.
