### PR TITLE
refactor: export `DropdownMenuItem` directly from `DropdownMenu`

### DIFF
--- a/src/components/AccentColorSelector.tsx
+++ b/src/components/AccentColorSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Dropdown } from './DropdownMenu';
+import { Dropdown, DropdownMenuItem } from './DropdownMenu';
 import { Arrow } from '@radix-ui/react-tooltip';
 import {
   TooltipProvider,
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@components/ui/tooltip';
-import { DropdownMenuItem } from '@components/ui/dropdown-menu';
+
 
 const themeOptions = [
   { colorName: 'Sky', colorClass: 'bg-sky-400', href: '#sky' },

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -6,6 +6,8 @@ import {
   DropdownMenuTrigger,
 } from '@components/ui/dropdown-menu';
 
+export { DropdownMenuItem } from '@components/ui/dropdown-menu';
+
 type DropdownProps = {
   children: [React.ReactNode, React.ReactNode];
   ariaLabel?: string;

--- a/src/components/ProjectsDropdown.tsx
+++ b/src/components/ProjectsDropdown.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Dropdown } from '@components/DropdownMenu';
+import { Dropdown, DropdownMenuItem } from './DropdownMenu';
 import { ChevronDown } from 'lucide-react';
-import { DropdownMenuItem } from '@components/ui/dropdown-menu';
 import { projectLinks } from './navLinks';
 
 export const ProjectsDropdown: React.FC = () => {


### PR DESCRIPTION
`DropdownMenuItem` is to be used as a child of `DropdownMenu`; Directly exporting `DropdownMenuItem` from `DropdownMenu` is more intuitive and convenient than exporting both components from different files.
