### PR TITLE
Update date handling, use formatted `pubDate` for blog and `ISOString` for JSONLD

### DIFF
--- a/src/components/BlogIndex.astro
+++ b/src/components/BlogIndex.astro
@@ -1,6 +1,6 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
-import { getCollection } from "astro:content";
+import { getCollection } from 'astro:content';
 
 const allPosts = await getCollection('posts');
 const { class: className, ...attrs } = Astro.props;
@@ -8,6 +8,13 @@ const { class: className, ...attrs } = Astro.props;
 let displayPosts = Astro.props.postCount
   ? allPosts.slice(-Astro.props.postCount)
   : allPosts;
+
+const formatDate = (date: Date) =>
+  new Date(date).toLocaleDateString('en-us', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
 
 interface Props extends HTMLAttributes<'ul'> {
   postCount?: number;
@@ -20,7 +27,7 @@ interface Props extends HTMLAttributes<'ul'> {
     displayPosts.map((post) => (
       <li class="grid grid-cols-1 border-b-[0.5px] p-2.5 sm:grid-cols-3">
         <div class="col-span-1 self-center text-dark/75 dark:text-muted-light/60">
-          {post.data.pubDate}
+          {formatDate(post.data.pubDate)}
         </div>
         <div class="col-span-2 sm:text-right">
           <a

--- a/src/layouts/MDLayout.astro
+++ b/src/layouts/MDLayout.astro
@@ -28,7 +28,7 @@ const jsonLD = {
   description: data.description,
   ...(data.image ? { image: imageUrl } : {}),
   url: Astro.request.url,
-  datePublished: isoDate + 'T08:00:00-05:00',
+  datePublished: isoDate,
   author: {
     '@type': 'Person',
     name: 'Bassim Shahidy',
@@ -65,7 +65,7 @@ const schema = JSON.stringify(jsonLD, null, 2);
         <div class="mb-1 flex justify-start">
           <span
             class="written-by max-w-fit rounded-md bg-accent-300/25 px-2 py-1 text-sm text-accent-500 dark:bg-accent-700/25 dark:text-accent-400">
-            Written by {data.author} on {data.pubDate}
+            Written by {data.author} on {formattedDate}
           </span>
         </div>
         <h1>{data.title}</h1>


### PR DESCRIPTION
Use `formatDate()` in `BlogIndex` to display formatted date
Use formatted `pubDate` for blog and `ISOString` for JSONLD