### PR TITLE
Refactor `DropdownMenu.tsx` to improve readability and code structure

### DIFF
--- a/src/components/AccentColorSelector.tsx
+++ b/src/components/AccentColorSelector.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Dropdown, DropdownMenuItem } from './DropdownMenu';
+import { DropdownMenu, DropdownMenuItem } from './DropdownMenu';
 import { Arrow } from '@radix-ui/react-tooltip';
 import {
   TooltipProvider,
@@ -57,7 +57,7 @@ export const AccentColorSelector: React.FC = () => {
 
   return (
     <TooltipProvider>
-      <Dropdown ariaLabel="Open accent color selector menu" variant="outline">
+      <DropdownMenu ariaLabel="Open accent color selector menu" variant="outline">
         <div className="flex items-center">
           <div className="size-5 rounded-full bg-accent-400" />
         </div>
@@ -82,7 +82,7 @@ export const AccentColorSelector: React.FC = () => {
             </TooltipContent>
           </Tooltip>
         ))}
-      </Dropdown>
+      </DropdownMenu>
     </TooltipProvider>
   );
 };

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Button } from '@components/ui/button';
 import {
-  DropdownMenu,
+  DropdownMenu as DropdownMenuPrimitive,
+  DropdownMenuItem,
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@components/ui/dropdown-menu';
-
-export { DropdownMenuItem } from '@components/ui/dropdown-menu';
 
 type DropdownProps = {
   children: [React.ReactNode, React.ReactNode];
@@ -22,26 +21,28 @@ type DropdownProps = {
     | undefined;
 };
 
-export const Dropdown: React.FC<DropdownProps> = ({
+const DropdownMenu: React.FC<DropdownProps> = ({
   children,
   variant,
   ariaLabel,
 }) => {
-  const [triggerChild, dropdownItem] = children;
+  const [dropdownTrigger, dropdownItem] = children;
 
   return (
-    <DropdownMenu>
+    <DropdownMenuPrimitive>
       <DropdownMenuTrigger asChild>
         <Button
           variant={variant}
           aria-label={ariaLabel}
           className="group flex h-9 px-2 text-muted-foreground hover:text-foreground/80 hover:no-underline data-[state='open']:bg-accent data-[state='open']:text-foreground/80">
-          {triggerChild}
+          {dropdownTrigger}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="min-w-fit" align="center">
         {dropdownItem}
       </DropdownMenuContent>
-    </DropdownMenu>
+    </DropdownMenuPrimitive>
   );
 };
+
+export { DropdownMenu, DropdownMenuItem };

--- a/src/components/ProjectsDropdown.tsx
+++ b/src/components/ProjectsDropdown.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Dropdown, DropdownMenuItem } from './DropdownMenu';
+import { DropdownMenu, DropdownMenuItem } from './DropdownMenu';
 import { ChevronDown } from 'lucide-react';
 import { projectLinks } from './navLinks';
 
 export const ProjectsDropdown: React.FC = () => {
   return (
-    <Dropdown variant="link" ariaLabel="Open projects dropdown menu">
+    <DropdownMenu variant="link" ariaLabel="Open projects dropdown menu">
       <span className="flex items-center">
         Projects
         <ChevronDown
@@ -23,6 +23,6 @@ export const ProjectsDropdown: React.FC = () => {
           {link.name}
         </DropdownMenuItem>
       ))}
-    </Dropdown>
+    </DropdownMenu>
   );
 };


### PR DESCRIPTION
- Use shadcn-ui `DropdownMenu` as `DropdownMenuPrimitive`

- Rename `Dropdown` to `DropdownMenu`, update usage in `AccentColorSelector.tsx` and `ProjectsDropdown.tsx`

- Export `DropdownMenu` and shadcn-ui `DropdownMenuItem` in the same export statement to make it more clear that that they must be used together

- Rename `triggerChild` slot to `dropdownTrigger`