### PR TITLE
Extract `formateDate` to it's own file, add options to configure when called

### DIFF
--- a/src/components/BlogIndex.astro
+++ b/src/components/BlogIndex.astro
@@ -1,6 +1,7 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
 import { getCollection } from 'astro:content';
+import { formatDate } from '@utils/formateDate';
 
 const allPosts = await getCollection('posts');
 const { class: className, ...attrs } = Astro.props;
@@ -8,13 +9,6 @@ const { class: className, ...attrs } = Astro.props;
 let displayPosts = Astro.props.postCount
   ? allPosts.slice(-Astro.props.postCount)
   : allPosts;
-
-const formatDate = (date: Date) =>
-  new Date(date).toLocaleDateString('en-us', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
 
 interface Props extends HTMLAttributes<'ul'> {
   postCount?: number;

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -12,12 +12,13 @@ import {
 } from '@/components/ui/command';
 import { Button } from '@/components/ui/button';
 
-import { cn } from '@/lib/utils';
-
 import { ArrowTopRightIcon } from '@radix-ui/react-icons';
 import { NotebookText } from 'lucide-react';
 
+import { cn } from '@/lib/utils';
+import { formatDate } from '@utils/formateDate';
 import { mainLinks, projectLinks, iconStyles } from './navLinks';
+
 
 type CommandMenuProps = {
   buttonStyles?: string;
@@ -112,10 +113,8 @@ export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
                 <NotebookText className={iconStyles} />
                 {post.data.title}
                 <CommandShortcut className="whitespace-nowrap tracking-wide">
-                  {new Date(post.data.pubDate).toLocaleDateString('en-US', {
-                    year: 'numeric',
+                  {formatDate(post.data.pubDate, {
                     month: 'short',
-                    day: 'numeric',
                   })}
                 </CommandShortcut>
               </CommandItem>

--- a/src/layouts/MDLayout.astro
+++ b/src/layouts/MDLayout.astro
@@ -1,17 +1,14 @@
 ---
-import TableOfContents from '@components/TableOfContents.astro';
+import { Image } from 'astro:assets';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import Prose from '@components/Prose.astro';
-import { Image } from 'astro:assets';
+import TableOfContents from '@components/TableOfContents.astro';
+import { formatDate } from '@utils/formateDate';
 import type { ImageMetadata } from 'astro';
+
 const { data, headings } = Astro.props;
 
 const isoDate = new Date(data.pubDate).toISOString();
-const formattedDate = new Date(data.pubDate).toLocaleDateString('en-us', {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-});
 
 const imageUrl = new URL(data.image?.url, Astro.request.url).href;
 const images = import.meta.glob<{ default: ImageMetadata }>(
@@ -58,14 +55,20 @@ const schema = JSON.stringify(jsonLD, null, 2);
 <BaseLayout {...data}>
   <script is:inline slot="head" type="application/ld+json" set:html={schema} />
   <div
-    class="grid grid-cols-1 justify-center lg:grid-cols-[1fr_240px] 2xl:grid-cols-[240px_1fr_240px]">
+    class="grid grid-cols-1 justify-center lg:grid-cols-[1fr_240px] 2xl:grid-cols-[240px_1fr_240px]"
+  >
     <div class="hidden 2xl:block"></div>
     <article class="mx-6 xs:mx-10">
       <Prose>
         <div class="mb-1 flex justify-start">
           <span
-            class="written-by max-w-fit rounded-md bg-accent-300/25 px-2 py-1 text-sm text-accent-500 dark:bg-accent-700/25 dark:text-accent-400">
-            Written by {data.author} on {formattedDate}
+            class="written-by max-w-fit rounded-md bg-accent-300/25 px-2 py-1 text-sm text-accent-500 dark:bg-accent-700/25 dark:text-accent-400"
+          >
+            Written by {data.author} on {
+              formatDate(data.pubDate, {
+                weekday: 'long',
+              })
+            }
           </span>
         </div>
         <h1>{data.title}</h1>

--- a/src/utils/formateDate.ts
+++ b/src/utils/formateDate.ts
@@ -1,0 +1,18 @@
+type DateOptions = Intl.DateTimeFormatOptions & {
+  weekday?: 'narrow' | 'short' | 'long';
+  year?: '2-digit' | 'numeric';
+  month?: '2-digit' | 'numeric' | 'narrow' | 'short' | 'long';
+  day?: '2-digit' | 'numeric';
+};
+
+export const formatDate = (date: Date, options: DateOptions = {}) => {
+  const defaultOptions: DateOptions = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  };
+
+  const finalOptions = { ...defaultOptions, ...options };
+
+  return new Date(date).toLocaleDateString('en-US', finalOptions);
+};


### PR DESCRIPTION
This PR centralizes date formatting by introducing a new utility function `formatDate`. This function is now used in `BlogIndex.astro`, `CommandMenu.tsx`, and `MDLayout.astro` replacing the previously inline date formatting.

---

- Extract `formateDate` to it's own file, add options to configure when called

- Use `formatDate` function from `formatDate.ts` util in `BlogIndex.astro`, `CommandMenu.tsx`, and `MDLayout.astro` to format dates based on the options passed to it