### PR TITLE
Disable CSS transitions when dark mode

### DIFF
--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -1,6 +1,23 @@
 import { Moon, Sun } from 'lucide-react';
 import { Button } from '@components/ui/button';
 
+const disableTransitions = () => {
+  const css = document.createElement('style');
+  css.textContent = `
+    * {
+      -webkit-transition: none !important;
+      -moz-transition: none !important;
+      -o-transition: none !important;
+      -ms-transition: none !important;
+      transition: none !important;
+    }
+  `;
+  document.head.appendChild(css);
+  requestAnimationFrame(() => {
+    document.head.removeChild(css);
+  });
+};
+
 export function ModeToggle() {
   const toggleTheme = () => {
     const currentTheme =
@@ -9,6 +26,8 @@ export function ModeToggle() {
         ? 'dark'
         : 'light');
     const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+    disableTransitions();
 
     document.documentElement.classList.toggle('dark', newTheme === 'dark');
     localStorage.setItem('themeToggle', newTheme);

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -46,6 +46,23 @@ const { ...attrs } = Astro.props;
 </style>
 
 <script is:inline>
+  function disableTransitions() {
+    const css = document.createElement('style');
+    css.textContent = `
+      * {
+        -webkit-transition: none !important;
+        -moz-transition: none !important;
+        -o-transition: none !important;
+        -ms-transition: none !important;
+        transition: none !important;
+      }
+    `;
+    document.head.appendChild(css);
+    requestAnimationFrame(() => {
+      document.head.removeChild(css);
+    });
+  }
+
   function toggleTheme() {
     const currentTheme =
       localStorage.getItem('themeToggle') ||
@@ -53,6 +70,8 @@ const { ...attrs } = Astro.props;
         ? 'dark'
         : 'light');
     const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+    disableTransitions();
 
     document.documentElement.classList.toggle('dark', newTheme === 'dark');
     localStorage.setItem('themeToggle', newTheme);


### PR DESCRIPTION
### TL;DR

This PR introduces a function that disables CSS transitions when toggling between light and dark themes.

### What changed?

A `disableTransitions` function has been added in `ModeToggle.tsx` and `ThemeToggle.astro` files to temporarily disable CSS transitions whenever the theme is switched, providing a smoother experience when switching between dark and light modes.

### How to test?

To test, you can switch between light and dark modes in the user interface and observe that transitions on elements don't appear during mode changes, but they do appear when they're intended to, i.e. when a button is hovered.

---

Update scripts, add `disableTransitions()`  to both mode toggle component implementations -`ModeToggle.astro` and `ThemeToggle.tsx`
 
This prevents the transition from being visible when toggling light and dark mode.