### PR TITLE
Create `useThemeToggle` hook in new hooks directory and add import alias

### DIFF
--- a/src/hooks/useThemeToggle.tsx
+++ b/src/hooks/useThemeToggle.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+
+const disableTransitions = () => {
+  const css = document.createElement('style');
+  css.textContent = `
+    * {
+      -webkit-transition: none !important;
+      -moz-transition: none !important;
+      -o-transition: none !important;
+      -ms-transition: none !important;
+      transition: none !important;
+    }
+  `;
+  document.head.appendChild(css);
+  requestAnimationFrame(() => {
+    document.head.removeChild(css);
+  });
+};
+
+export const useThemeToggle = () => {
+  const toggleTheme = () => {
+    const currentTheme =
+      localStorage.getItem('themeToggle') ||
+      (window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light');
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+    disableTransitions();
+
+    document.documentElement.classList.toggle('dark', newTheme === 'dark');
+    localStorage.setItem('themeToggle', newTheme);
+  };
+
+  return { toggleTheme };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
       "@utils/*": [
         "src/utils/*"
       ],
+      "@hooks/*": [
+        "src/hooks/*"
+      ],
       "@/*" : [
         "./src/*"
       ]


### PR DESCRIPTION
### TL;DR

This PR introduces a new hook `useThemeToggle` and updates the `tsconfig.json`.

- Create `useThemeToggle` hook using logic from `ModeToggle`

- Add hooks directory and `@hooks` import alias to `tsconfig.json`
### What changed?

A new file `useThemeToggle.tsx` was added in the new `src/hooks/` directory. This hook provides a reusable `toggleTheme` function that changes the theme between dark and light mode.

The `tsconfig.json` is updated with an import alias for the new hooks directory.