### PR TITLE
Use `useThemeToggle` hook in `CommandMenu` and  `ModeToggle`

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useThemeToggle } from '@hooks/useThemeToggle';
 
 import {
   CommandDialog,
@@ -14,11 +15,11 @@ import { Button } from '@/components/ui/button';
 
 import { ArrowTopRightIcon } from '@radix-ui/react-icons';
 import { NotebookText } from 'lucide-react';
+import { Moon, Sun } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { formatDate } from '@utils/formateDate';
 import { mainLinks, projectLinks, iconStyles } from './navLinks';
-
 
 type CommandMenuProps = {
   buttonStyles?: string;
@@ -27,6 +28,7 @@ type CommandMenuProps = {
 
 export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
   const [open, setOpen] = React.useState(false);
+  const { toggleTheme } = useThemeToggle();
 
   const handleKeyDown = (event: KeyboardEvent) => {
     const { metaKey, ctrlKey, key, target } = event;
@@ -119,6 +121,14 @@ export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
                 </CommandShortcut>
               </CommandItem>
             ))}
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Settings">
+            <CommandItem onSelect={toggleTheme}>
+              <Sun className="size-4 mr-2 dark:hidden" />
+              <Moon className="hidden size-4 mr-2 dark:block" />
+              Toggle theme
+            </CommandItem>
           </CommandGroup>
         </CommandList>
       </CommandDialog>

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -1,37 +1,9 @@
 import { Moon, Sun } from 'lucide-react';
 import { Button } from '@components/ui/button';
-
-const disableTransitions = () => {
-  const css = document.createElement('style');
-  css.textContent = `
-    * {
-      -webkit-transition: none !important;
-      -moz-transition: none !important;
-      -o-transition: none !important;
-      -ms-transition: none !important;
-      transition: none !important;
-    }
-  `;
-  document.head.appendChild(css);
-  requestAnimationFrame(() => {
-    document.head.removeChild(css);
-  });
-};
+import { useThemeToggle } from '@hooks/useThemeToggle';
 
 export function ModeToggle() {
-  const toggleTheme = () => {
-    const currentTheme =
-      localStorage.getItem('themeToggle') ||
-      (window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light');
-    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-
-    disableTransitions();
-
-    document.documentElement.classList.toggle('dark', newTheme === 'dark');
-    localStorage.setItem('themeToggle', newTheme);
-  };
+  const { toggleTheme } = useThemeToggle();
 
   return (
     <Button


### PR DESCRIPTION
### TL;DR

This pull request improves theme toggling by incorporating the `useThemeToggle` hook
- Remove theme toggle logic from `ModeToggle`, import and use `useThemeToggle` hook instead.
- Add `CommandMenuItem` which uses `useThemeToggle` hook to toggle theme from within the `CommandMenu` component.

### What changed?

The code implements to use of the `useThemeToggle` in the `CommandMenu` and replaces the logic in the `ModeToggle` components. A new settings option in the `CommandMenu` has been added to toggle the theme.

### How to test?

Check if the theme toggle is working properly in both the `CommandMenu` and the `ModeToggle` components.

### Why make this change?

This change is made to make the theme toggling more reusable by using a dedicated hook. This change was made to facilitate the use of theme toggle functionality within a `CommandMenuItem`, or any other component without added complexity or inefficient code. This also separates logic from UI in `ModeToggle.tsx`

