### PR TITLE
Create `getSortedPosts.astro` util to sort blog posts by published date

### DIFF
--- a/src/utils/getSortedPosts.astro
+++ b/src/utils/getSortedPosts.astro
@@ -1,0 +1,9 @@
+---
+import { getCollection } from 'astro:content';
+
+export const sortedBlogPosts = (await getCollection('posts')).sort(
+  (a, b) =>
+    Date.parse(b.data.pubDate.toString()) -
+    Date.parse(a.data.pubDate.toString())
+);
+---


### PR DESCRIPTION
This allows this function to be imported to provide a list of blog posts sorted by date.