### PR TITLE
Replace `getCollection` in `Blogindex.astro` with `sortedBlogPosts` function, update styling

### DIFF
--- a/src/components/BlogIndex.astro
+++ b/src/components/BlogIndex.astro
@@ -1,24 +1,22 @@
 ---
-import type { HTMLAttributes } from 'astro/types';
-import { getCollection } from 'astro:content';
 import { formatDate } from '@utils/formateDate';
+import { sortedBlogPosts } from '@utils/getSortedPosts.astro';
 
-const allPosts = await getCollection('posts');
-const { class: className, ...attrs } = Astro.props;
+const { class: className } = Astro.props;
 
-let displayPosts = Astro.props.postCount
-  ? allPosts.slice(-Astro.props.postCount)
-  : allPosts;
+let latestPosts = Astro.props.postCount
+  ? sortedBlogPosts.slice(0, Astro.props.postCount)
+  : sortedBlogPosts;
 
-interface Props extends HTMLAttributes<'ul'> {
+interface Props {
   postCount?: number;
   class?: string;
 }
 ---
 
-<ul class={`list-none pl-0 ${className}`} {...attrs}>
+<ul class={`list-none pl-0 ${className}`}>
   {
-    displayPosts.map((post) => (
+    latestPosts.map((post) => (
       <li class="grid grid-cols-1 border-b-[0.5px] p-2.5 sm:grid-cols-3">
         <div class="col-span-1 self-center text-dark/75 dark:text-muted-light/60">
           {formatDate(post.data.pubDate)}
@@ -27,7 +25,7 @@ interface Props extends HTMLAttributes<'ul'> {
           <a
             href={`/posts/${post.slug}/`}
             aria-label={`Link to blog post: ${post.data.title}`}
-            class="block text-xl font-[600] text-dark underline decoration-accent-500 decoration-2 underline-offset-[5px] hover:text-dark/80 hover:decoration-accent-300 dark:text-light dark:decoration-accent-500 dark:hover:text-muted-light/75 dark:hover:underline dark:hover:decoration-accent-600/80">
+            class="block text-balance text-xl font-[600] text-dark underline decoration-accent-500 decoration-2 underline-offset-[5px] hover:text-dark/80 hover:decoration-accent-300 dark:text-light dark:decoration-accent-500 dark:hover:text-muted-light/75 dark:hover:underline dark:hover:decoration-accent-600/80">
             {post.data.title}
           </a>
         </div>

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -21,13 +21,13 @@ import { Moon, Sun } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDate } from '@utils/formateDate';
 import { mainLinks, projectLinks, iconStyles } from './navLinks';
+import { sortedBlogPosts } from '@utils/getSortedPosts.astro';
 
 type CommandMenuProps = {
   buttonStyles?: string;
-  posts?: any[];
 };
 
-export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
+export function CommandMenu({ buttonStyles }: CommandMenuProps) {
   const [open, setOpen] = React.useState(false);
   const { toggleTheme } = useThemeToggle();
 
@@ -106,7 +106,7 @@ export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
           </CommandGroup>
           <CommandSeparator />
           <CommandGroup heading="Blog Posts">
-            {posts?.map((post, index) => (
+            {sortedBlogPosts.map((post, index) => (
               <CommandItem
                 slot="blogPosts"
                 key={index}

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -1,5 +1,4 @@
 ---
-import { getCollection } from "astro:content";
 import { Button } from '@components/ui/button';
 import { ModeToggle } from '@components/ModeToggle';
 import { SideMenu } from '@components/SideMenu';
@@ -8,8 +7,6 @@ import { mainLinks } from './navLinks';
 import Logo from './Logo.astro';
 import { AccentColorSelector } from './AccentColorSelector';
 import { ProjectsDropdown } from './ProjectsDropdown';
-
-const allPosts = await getCollection('posts');
 ---
 
 <header
@@ -37,7 +34,7 @@ const allPosts = await getCollection('posts');
       </span>
     </nav>
     <span class="flex items-center gap-2">
-      <CommandMenu client:load posts={allPosts} />
+      <CommandMenu client:load />
       <AccentColorSelector client:load />
       <SideMenu client:load />
       <ModeToggle client:load />


### PR DESCRIPTION
Replace `getCollection` in `Blogindex.astro` with `sortedBlogPosts` function, update styling

Rename `displayPosts` to `latestPosts` and use `sortedBlogPosts` instead of `allPosts` from `getCollection`

Remove HTMLAttributes extension from `Blogindex.astro`

Add text-balance to `Blogindex.astro` titles

Replace `getCollection` method and prop in `ReactHeader` with `sortedBlogPosts` imported directly into `CommandMenu`