### PR TITLE
Convert `getSortedPosts` util from astro to typescript

### DIFF
--- a/src/components/BlogIndex.astro
+++ b/src/components/BlogIndex.astro
@@ -1,6 +1,6 @@
 ---
 import { formatDate } from '@utils/formateDate';
-import { sortedBlogPosts } from '@utils/getSortedPosts.astro';
+import { sortedBlogPosts } from '@utils/getSortedPosts';
 
 const { class: className } = Astro.props;
 

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -21,7 +21,7 @@ import { Moon, Sun } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDate } from '@utils/formateDate';
 import { mainLinks, projectLinks, iconStyles } from './navLinks';
-import { sortedBlogPosts } from '@utils/getSortedPosts.astro';
+import { sortedBlogPosts } from '@utils/getSortedPosts';
 
 type CommandMenuProps = {
   buttonStyles?: string;

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -1,4 +1,3 @@
----
 import { getCollection } from 'astro:content';
 
 export const sortedBlogPosts = (await getCollection('posts')).sort(
@@ -6,4 +5,3 @@ export const sortedBlogPosts = (await getCollection('posts')).sort(
     Date.parse(b.data.pubDate.toString()) -
     Date.parse(a.data.pubDate.toString())
 );
----


### PR DESCRIPTION
The Astro `getCollection` API is not exclusive to Astro files, so this util is converted to typescript.

Imports updated to remove `.astro` extension
