### PR TITLE
Add type to `getCollection`, remove unused imports, update styles

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -16,12 +16,11 @@ import { Button } from '@/components/ui/button';
 
 import { ArrowTopRightIcon } from '@radix-ui/react-icons';
 import { NotebookText } from 'lucide-react';
-import { Moon, Sun } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { formatDate } from '@utils/formateDate';
-import { mainLinks, projectLinks, iconStyles } from './navLinks';
 import { sortedBlogPosts } from '@utils/getSortedPosts';
+import { mainLinks, projectLinks, iconStyles } from './navLinks';
 
 type CommandMenuProps = {
   buttonStyles?: string;
@@ -110,12 +109,12 @@ export function CommandMenu({ buttonStyles }: CommandMenuProps) {
               <CommandItem
                 slot="blogPosts"
                 key={index}
-                className="mr-2 text-balance"
+                className="text-balance"
                 aria-label={`Link to blog post: ${post.data.title}`}
                 onSelect={() => navigate(`/posts/${post.slug}/`)}>
                 <NotebookText className={iconStyles} />
                 {post.data.title}
-                <CommandShortcut className="whitespace-nowrap tracking-wide">
+                <CommandShortcut className="whitespace-nowrap pl-4 tracking-wide">
                   {formatDate(post.data.pubDate, {
                     month: 'short',
                   })}

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -1,5 +1,4 @@
 ---
-import { getCollection } from "astro:content";
 import Button from './Button.astro';
 import DropdownMenu from './DropdownMenu.astro';
 import ThemeToggle from './ThemeToggle.astro';
@@ -8,19 +7,10 @@ import { CommandMenu } from '@components/CommandMenu';
 import { SideMenu } from '@components/SideMenu';
 import Logo from './Logo.astro';
 import { projectLinks } from './navLinks';
-
-const allPosts = await getCollection('posts');
-
-import type { HTMLAttributes } from 'astro/types';
-
-type Props = HTMLAttributes<'div'>;
-
-const { ...attrs } = Astro.props;
 ---
 
 <div
-  class="navbar-container sticky top-0 z-10 mb-8 w-full border-b border-border bg-background"
-  {...attrs}>
+  class="navbar-container sticky top-0 z-10 mb-8 w-full border-b border-border bg-background">
   <div
     class="h-1 w-full bg-gradient-to-r from-accent-300 via-accent-500 to-accent-400">
   </div>
@@ -28,7 +18,7 @@ const { ...attrs } = Astro.props;
     class="button-container flex items-center justify-between px-4 py-2 text-dark dark:text-light sm:px-6 md:px-10 xl:px-14">
     <span class="flex items-center">
       <Logo class="mr-4" />
-      <CommandMenu client:load buttonStyles="h-8 pr-1" posts={allPosts} />
+      <CommandMenu client:load buttonStyles="h-8 pr-1" />
     </span>
     <div class="button-theme-container flex items-center gap-1">
       <div class="gap-1 text-[15px] sm:flex">

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -1,6 +1,9 @@
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 
-export const sortedBlogPosts = (await getCollection('posts')).sort(
+type posts = CollectionEntry<'posts'>;
+
+export const sortedBlogPosts: posts[] = (await getCollection('posts')).sort(
   (a, b) =>
     Date.parse(b.data.pubDate.toString()) -
     Date.parse(a.data.pubDate.toString())


### PR DESCRIPTION
- Add `CollectionEntry` type to `getSortedPosts`
* Update blog group styles, remove unused icon import in `CommandMenu.tsx`
- Remove unused `getCollection` and HTML attribute extension from `NavBar.astro`
  - Posts are not passed as a prop anymore, they're being accessed directly in `CommandMenu.tsx` so `getCollection` is no longer needed in `NavBar.astro`