### PR TITLE
Remove direct `sortedBlogPosts` import from `CommandMenu.tsx`

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -19,14 +19,18 @@ import { NotebookText } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { formatDate } from '@utils/formatDate';
-import { sortedBlogPosts } from '@utils/getSortedPosts';
 import { mainLinks, projectLinks, iconStyles } from './navLinks';
+
+import type { CollectionEntry } from 'astro:content';
+type postsType = CollectionEntry<'posts'>[];
+
 
 type CommandMenuProps = {
   buttonStyles?: string;
+  posts?: postsType;
 };
 
-export function CommandMenu({ buttonStyles }: CommandMenuProps) {
+export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
   const [open, setOpen] = React.useState(false);
   const { toggleTheme } = useThemeToggle();
 
@@ -105,7 +109,7 @@ export function CommandMenu({ buttonStyles }: CommandMenuProps) {
           </CommandGroup>
           <CommandSeparator />
           <CommandGroup heading="Blog Posts">
-            {sortedBlogPosts.map((post, index) => (
+            {posts?.map((post, index) => (
               <CommandItem
                 slot="blogPosts"
                 key={index}

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -7,6 +7,7 @@ import { CommandMenu } from '@components/CommandMenu';
 import { SideMenu } from '@components/SideMenu';
 import Logo from './Logo.astro';
 import { projectLinks } from './navLinks';
+import { sortedBlogPosts } from '@utils/getSortedPosts';
 ---
 
 <div
@@ -18,7 +19,7 @@ import { projectLinks } from './navLinks';
     class="button-container flex items-center justify-between px-4 py-2 text-dark dark:text-light sm:px-6 md:px-10 xl:px-14">
     <span class="flex items-center">
       <Logo class="mr-4" />
-      <CommandMenu client:load buttonStyles="h-8 pr-1" />
+      <CommandMenu client:load buttonStyles="h-8 pr-1" posts={sortedBlogPosts} />
     </span>
     <div class="button-theme-container flex items-center gap-1">
       <div class="gap-1 text-[15px] sm:flex">

--- a/src/components/ReactHeader.astro
+++ b/src/components/ReactHeader.astro
@@ -7,6 +7,7 @@ import { mainLinks } from './navLinks';
 import Logo from './Logo.astro';
 import { AccentColorSelector } from './AccentColorSelector';
 import { ProjectsDropdown } from './ProjectsDropdown';
+import { sortedBlogPosts } from '@utils/getSortedPosts';
 ---
 
 <header
@@ -34,7 +35,7 @@ import { ProjectsDropdown } from './ProjectsDropdown';
       </span>
     </nav>
     <span class="flex items-center gap-2">
-      <CommandMenu client:load />
+      <CommandMenu client:load posts={sortedBlogPosts} />
       <AccentColorSelector client:load />
       <SideMenu client:load />
       <ModeToggle client:load />

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -1,8 +1,8 @@
 import { getCollection } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
 
-type posts = CollectionEntry<'posts'>;
+type posts = CollectionEntry<'posts'>[];
 
-export const sortedBlogPosts: posts[] = (await getCollection('posts')).sort(
+export const sortedBlogPosts: posts = (await getCollection('posts')).sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );


### PR DESCRIPTION
- Remove direct `sortedBlogPosts` import from `CommandMenu.tsx`

- Use prop instead to pass `sortedBlogPosts` to `CommandMenu` in `ReactHeader` and `NavBar` components

- Update type in `getSortedBlogPosts`

- Array is used when assigning type to posts, rather than on posts within the const declaration