### PR TITLE
Update styling for hero, card, logo, projects, and about page

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -25,7 +25,7 @@ const {
 } = Astro.props;
 
 const baseStyles: string =
-  'prose prose-slate max-w-3xl rounded-lg dark:prose-invert prose-h2:font-semibold prose-h2:opacity-80 dark:prose-h2:opacity-60';
+  'prose prose-slate prose-h1:text-5xl max-w-3xl rounded-lg dark:prose-invert prose-h2:font-semibold prose-h2:text-xl prose-h2:text-muted-foreground';
 
 const variableStyles: (string | undefined)[] = [
   padding,

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -25,7 +25,7 @@ const {
 } = Astro.props;
 
 const baseStyles: string =
-  'prose prose-slate prose-h1:text-5xl max-w-3xl rounded-lg dark:prose-invert prose-h2:font-semibold prose-h2:text-xl prose-h2:text-muted-foreground';
+  'prose prose-slate max-w-3xl rounded-lg dark:prose-invert prose-h2:font-semibold prose-h2:text-xl prose-h2:text-muted-foreground';
 
 const variableStyles: (string | undefined)[] = [
   padding,

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -10,7 +10,7 @@ interface Props {
 
 <a href="/" aria-label="logo, link to homepage" class={className}>
   <span
-    class="logo flex h-9 items-center gap-x-2.5 pb-0.5 text-xl font-bold text-foreground dark:text-muted-light">
+    class="logo flex h-9 items-center gap-x-2.5 pb-0.5 text-xl font-extrabold text-foreground dark:text-muted-light">
     <Icon name="shadlogo" size={20} />
     bassim
   </span>

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -10,7 +10,7 @@ const { ...attrs } = Astro.props;
 ---
 
 <div class="card-mx card-p" {...attrs}>
-  <div class="mb-4 text-2xl font-extrabold">
+  <div class="text-2xl font-extrabold mb-4">
     <h1>projects</h1>
   </div>
   <ul class="grid list-none gap-4 pl-0 md:grid-cols-2">
@@ -36,7 +36,7 @@ const { ...attrs } = Astro.props;
               </p>
               <div class="flex flex-wrap gap-2">
                 {project.data.tags.map((tag) => (
-                  <div class="rounded-xl border border-accent-400 bg-accent-50 px-2 py-1 text-sm text-accent-700/85 dark:border-accent-500/15 dark:bg-accent-500/10 dark:text-accent-300">
+                  <div class="rounded-xl border border-accent-400 bg-accent-50 px-2 py-[3px] text-xs text-accent-700/85 dark:border-accent-500/15 dark:bg-accent-500/10 dark:text-accent-300">
                     {tag}
                   </div>
                 ))}

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -31,7 +31,7 @@ const { ...attrs } = Astro.props;
                 </span>
                 <Icon name="github" class="mx-2 opacity-70 hover:opacity-100" />
               </a>
-              <p class="mb-2 mt-0 line-clamp-2 opacity-85 text-[0.925rem]">
+              <p class="mb-4 mt-1.5 line-clamp-2 opacity-85 text-[0.925rem]">
                 {project.data.description}
               </p>
               <div class="flex flex-wrap gap-2">

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -10,28 +10,28 @@ const { ...attrs } = Astro.props;
 ---
 
 <div class="card-mx card-p" {...attrs}>
-  <div class="h1 mb-4">
-    <h1>Projects</h1>
+  <div class="mb-4 text-2xl font-extrabold">
+    <h1>projects</h1>
   </div>
   <ul class="grid list-none gap-4 pl-0 md:grid-cols-2">
     {
       projects.map((project) => (
         <li>
-          <Card variant="bordered" padding="p-3.5" noMargin={true}>
+          <Card
+            variant="bordered"
+            padding="px-4 pt-3 pb-4"
+            noMargin={true}>
             <div slot="content">
               <a
                 aria-label="github project link"
-                class="flex items-center justify-between text-[1.2rem] font-semibold no-underline"
+                class="flex items-center justify-between text-[1.1rem] font-extrabold no-underline"
                 href={project.data.url}>
                 <span class="dark:text-light hover:dark:text-muted-light/75">
                   {project.data.title}
                 </span>
-                <Icon
-                  name="github"
-                  class="mx-2 size-5 opacity-70 hover:opacity-100"
-                />
+                <Icon name="github" class="mx-2 opacity-70 hover:opacity-100" />
               </a>
-              <p class="mt-2.5 line-clamp-2 text-[0.925rem]">
+              <p class="mb-2 mt-0 line-clamp-2 opacity-85 text-[0.925rem]">
                 {project.data.description}
               </p>
               <div class="flex flex-wrap gap-2">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,30 +6,26 @@ import Card from '@components/Card.astro';
 <MainLayout title="About Me" description="Bassim Shahidy's personal website">
   <section>
     <Card
-      title="My First Astro Website"
-      subtitle="Styled with Tailwind CSS"
+      title="Bassim Shahidy"
+      subtitle="IT/AV professional learning web development"
       variant="bordered"
       displayHr={true}>
-      <p slot="content">
-        This is the third version of my personal website! With each iteration my
-        website has grown in complexity in proportion to my progress learning
-        web development. This version is built with Astro, a frontend rendering
-        framework that uses an HTML like syntax to create components while
-        allowing the use of components from several of the most popular
-        frameworks.
-      </p>
-      <p slot="content">
-        Astro is also extremely fast, it uses the islands architecture to only
-        send Javascript when required within interactive components.
-      </p>
-      <p slot="content">
-        For more information on Astro and how I used it to build this website,
-        visit <a
-          href="posts/buildingthissitewithastro"
-          class="font-semibold hover:text-muted-light/85"
-          >How I built this website</a
-        >.
-      </p>
+        <p slot="content">
+          Based in NY, I'm an IT Professional with a wealth of experience in
+          hardware, software management, network operations, cybersecurity, and
+          audio-visual systems. Currently, my focus is on advancing my skillset
+          in software engineering and web development, utilizing the latest
+          programming technologies to enhance user experiences and system
+          performance.
+        </p>
+        <p slot="content">
+          In addition, I'm exploring AI and machine learning, seeking to
+          understand and apply these technologies in practical scenarios. My
+          technical repertoire also includes 3D printing—where I skillfully
+          build and maintain printers for precision parts—and drone building,
+          where I apply my electronics and software knowledge to create and
+          pilot high-performance drones.
+        </p>
     </Card>
   </section>
 </MainLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,7 +4,7 @@ import MainLayout from '@layouts/MainLayout.astro';
 
 <MainLayout title="About Me" description="Bassim Shahidy's personal website">
   <section class="card-mx mt-8 card-p max-w-3xl">
-    <h3 class="mb-4 text-2xl font-bold">About Me</h3>
+    <h3 class="mb-4 text-xl font-semibold">About Me</h3>
     <div slot="content" class="space-y-6">
       <p class="text-muted-foreground">
         Based in NY, I'm an IT Professional with a wealth of experience in

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,31 +1,29 @@
 ---
 import MainLayout from '@layouts/MainLayout.astro';
-import Card from '@components/Card.astro';
 ---
 
 <MainLayout title="About Me" description="Bassim Shahidy's personal website">
-  <section>
-    <Card
-      title="Bassim Shahidy"
-      subtitle="IT/AV professional learning web development"
-      variant="bordered"
-      displayHr={true}>
-        <p slot="content">
-          Based in NY, I'm an IT Professional with a wealth of experience in
-          hardware, software management, network operations, cybersecurity, and
-          audio-visual systems. Currently, my focus is on advancing my skillset
-          in software engineering and web development, utilizing the latest
-          programming technologies to enhance user experiences and system
-          performance.
-        </p>
-        <p slot="content">
-          In addition, I'm exploring AI and machine learning, seeking to
-          understand and apply these technologies in practical scenarios. My
-          technical repertoire also includes 3D printing—where I skillfully
-          build and maintain printers for precision parts—and drone building,
-          where I apply my electronics and software knowledge to create and
-          pilot high-performance drones.
-        </p>
-    </Card>
+  <section class="card-mx mt-8 card-p max-w-3xl">
+    <h3 class="mb-4 text-2xl font-bold">About Me</h3>
+    <div slot="content" class="space-y-6">
+      <p class="text-muted-foreground">
+        Based in NY, I'm an IT Professional with a wealth of experience in
+        hardware, software management, network operations, cybersecurity, and
+        audio-visual systems.
+      </p>
+      <p class="text-muted-foreground">
+        Currently, my focus is on advancing my skillset in software engineering
+        and web development, utilizing the latest programming technologies to
+        enhance user experiences and system performance.
+      </p>
+      <p class="text-muted-foreground">
+        In addition, I'm exploring AI and machine learning, seeking to
+        understand and apply these technologies in practical scenarios. My
+        technical repertoire also includes 3D printing—where I skillfully build
+        and maintain printers for precision parts—and drone building, where I
+        apply my electronics and software knowledge to create and pilot
+        high-performance drones.
+      </p>
+    </div>
   </section>
 </MainLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,30 +10,16 @@ import Projects from '@components/Projects.astro';
   description="Bassim Shahidy's personal website">
   <body>
     <div class="max-w-3xl">
-      <Card
-        title="Bassim Shahidy"
-        subtitle="IT Specialist at the New York City BAR Association"
-        variant="borderless">
-        <p slot="content">
-          Based in NY, I'm an IT Professional with a wealth of experience in
-          hardware, software management, network operations, cybersecurity, and
-          audio-visual systems. Currently, my focus is on advancing my skillset
-          in software engineering and web development, utilizing the latest
-          programming technologies to enhance user experiences and system
-          performance.
-        </p>
-        <p slot="content">
-          In addition, I'm exploring AI and machine learning, seeking to
-          understand and apply these technologies in practical scenarios. My
-          technical repertoire also includes 3D printing—where I skillfully
-          build and maintain printers for precision parts—and drone building,
-          where I apply my electronics and software knowledge to create and
-          pilot high-performance drones.
-        </p>
-      </Card>
+      <section class="my-24 w-5/6">
+        <Card
+          title="hi, i'm bassim"
+          subtitle="I'm an IT/AV Specialist from New York learning web development"
+          variant="borderless"
+        />
+      </section>
       <div class="card-mx card-p">
-        <div class="h1 mb-3">
-          <h1>Latest Posts</h1>
+        <div class="mb-3 text-2xl font-extrabold">
+          <h1>blog</h1>
         </div>
         <BlogIndex postCount={3} />
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,9 +17,11 @@ import Projects from '@components/Projects.astro';
           variant="borderless"
         />
       </section> -->
-      <section class="my-24 w-5/6 card-mx card-p">
-        <h1 class="text-[2.5rem] font-extrabold mb-2">hi, i'm bassim</h1>
-        <h2 class="text-xl font-semibold text-muted-foreground ">I'm an IT/AV Specialist from New York learning web development</h2>
+      <section class="my-24 card-mx card-p">
+        <div class="w-5/6">
+          <h1 class="text-[2.5rem] font-extrabold mb-2">hi, i'm bassim</h1>
+          <h2 class="text-xl font-semibold text-muted-foreground ">I'm an IT/AV Specialist from New York learning web development</h2>
+        </div>
       </section>
       <div class="card-mx card-p">
         <div class="mb-3 text-2xl font-extrabold">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,12 +10,16 @@ import Projects from '@components/Projects.astro';
   description="Bassim Shahidy's personal website">
   <body>
     <div class="max-w-3xl">
-      <section class="my-24 w-5/6">
+      <!-- <section class="my-24 w-5/6">
         <Card
           title="hi, i'm bassim"
           subtitle="I'm an IT/AV Specialist from New York learning web development"
           variant="borderless"
         />
+      </section> -->
+      <section class="my-24 w-5/6 card-mx card-p">
+        <h1 class="text-[2.5rem] font-extrabold mb-2">hi, i'm bassim</h1>
+        <h2 class="text-xl font-semibold text-muted-foreground ">I'm an IT/AV Specialist from New York learning web development</h2>
       </section>
       <div class="card-mx card-p">
         <div class="mb-3 text-2xl font-extrabold">


### PR DESCRIPTION
`Projects.astro`: Update padding and margin, make title font size smaller and extrabold, make Github icon smaller

`index.astro`: Remove use of card component for hero,  wrap in div, use section, h1, and h2 tags, add `w-5/6`

`about.astro`: Move index text to about page, update hero to be more minimal
- Remove `Card.astro` from about page, separate text into 3 paragraphs, update text color to `muted-foreground`

Change `BlogIndex.astro` and projects section heading sizes, make them smaller

`Logo.astro`: make logo text extrabold