### PR TITLE
`BlogIndex.astro`, `index.astro`: Update font weights

### DIFF
--- a/src/components/BlogTimeline.astro
+++ b/src/components/BlogTimeline.astro
@@ -47,7 +47,7 @@ const { lineClamp, split = false } = Astro.props;
             ]}>
             <time>{formatDate(post.data.pubDate)}</time>
           </div>
-          <h2 class="mb-1 font-semibold">{post.data.title}</h2>
+          <h2 class="mb-1 font-medium">{post.data.title}</h2>
         </header>
 
         <p class:list={['mb-3 text-muted-foreground', lineClamp]}>

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -10,21 +10,19 @@ import { Icon } from 'astro-icon/components';
     {
       projects.map((project) => (
         <li>
-          <Card
-            variant="bordered"
-            padding="px-4 pt-3 pb-4"
-            noMargin={true}>
+          <Card variant="bordered" padding="px-4 pt-3 pb-4" noMargin={true}>
             <div slot="content">
               <a
                 aria-label="github project link"
-                class="flex items-center justify-between text-[1.1rem] font-extrabold no-underline"
+                class="group flex items-center justify-between font-bold text-foreground/85 no-underline hover:text-foreground"
                 href={project.data.url}>
-                <span class="dark:text-light hover:dark:text-muted-light/75">
-                  {project.data.title}
-                </span>
-                <Icon name="github" class="mx-2 opacity-70 hover:opacity-100" />
+                {project.data.title}
+                <Icon
+                  name="github"
+                  class="mx-2 text-muted-foreground group-hover:text-foreground"
+                />
               </a>
-              <p class="mb-4 mt-1.5 line-clamp-2 opacity-85 text-[0.925rem]">
+              <p class="mb-4 mt-1.5 line-clamp-2 text-[0.925rem] text-muted-foreground">
                 {project.data.description}
               </p>
               <div class="flex flex-wrap gap-2">

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -29,7 +29,7 @@ function buildToc(headings: Heading[]) {
 ---
 
 <nav
-  class="toc prose sticky top-28 mt-28 w-[240px] text-[0.8em] leading-normal dark:prose-invert prose-a:text-muted-dark prose-a:transition-colors dark:prose-a:text-muted-light/60 lg:pl-2 xl:pl-4">
+  class="toc prose sticky top-28 mt-28 w-[240px] text-[0.8em] leading-normal dark:prose-invert prose-a:text-muted-foreground prose-a:transition-colors lg:pl-2 xl:pl-4">
   <ul class="grid list-none">
     {
       toc.map((heading) => (

--- a/src/components/TableOfContentsHeading.astro
+++ b/src/components/TableOfContentsHeading.astro
@@ -37,14 +37,14 @@ import { Icon } from 'astro-icon/components';
 
 <style>
   li:has(.active) > a {
-    @apply text-accent-400 hover:text-accent-300;
+    @apply text-accent-400;
   }
 
   :root:is(.dark) li:has(.active) > a {
-    @apply text-accent-300/70 hover:text-accent-300/90;
+    @apply text-accent-300;
   }
 
   a:hover {
-    @apply text-muted dark:text-muted-light/80;
+    @apply text-foreground/80;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,13 +15,13 @@ import Projects from '@components/Projects.astro';
       </h2>
     </section>
     <section id="latest posts" class="mb-24"> 
-      <h1 class="text-xl font-bold">Latest Posts</h1>
+      <h1 class="text-xl font-semibold">Latest Posts</h1>
       <div>
         <BlogTimeline postCount={3} lineClamp="line-clamp-2" />
       </div>
     </section>
     <section id="projects">
-      <h1 class="mb-6 text-xl font-bold text-foreground">Projects</h1>
+      <h1 class="mb-6 text-xl font-semibold text-foreground">Projects</h1>
       <Projects />
     </section>
   </article>


### PR DESCRIPTION
* `BlogIndex.astro`, `index.astro`: Update font weights
* `Projects.astro`: Make text colors, sizes, and weights more consistent
   * Make colors more consistent with rest of site
   * Make sizing and weight more consistent with page hierarchy

- Update TableOfContents text colors with shadcn variables
  - Ensures consistency with the rest of the site
  - Brightens TOC, increases contrast and appearance of links