### PR TITLE
Update `ChatUI` select styling, add more model options

### DIFF
--- a/src/components/ChatUI.tsx
+++ b/src/components/ChatUI.tsx
@@ -13,41 +13,9 @@ import {
   SelectLabel,
   SelectItem,
 } from '@components/ui/select';
-import { Textarea } from './ui/textarea';
-
+import { Textarea } from '@/components/ui/textarea';
+import { useModel } from '@/hooks/useModel';
 import { useChat, type UseChatHelpers, type UseChatOptions } from 'ai/react';
-
-const useModel = (defaultModel: string) => {
-  const localStorageAvailable =
-    typeof window !== 'undefined' && window.localStorage;
-    
-  const [selectedModel, setSelectedModel] = React.useState<string>(() => {
-    if (localStorageAvailable) {
-      return localStorage.getItem('selectedModel') || defaultModel;
-    }
-    return defaultModel;
-  });
-
-  const handleModelChange = (model: string) => {
-    setSelectedModel(model);
-    if (localStorageAvailable) {
-      localStorage.setItem('selectedModel', model);
-    }
-  };
-
-  React.useEffect(() => {
-    const sendModelName = async () => {
-      await fetch('/api/chatRoute', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ modelName: selectedModel }),
-      });
-    };
-    sendModelName();
-  }, [selectedModel]);
-
-  return { selectedModel, handleModelChange };
-};
 
 const modelGroups = [
   {

--- a/src/components/ChatUI.tsx
+++ b/src/components/ChatUI.tsx
@@ -111,22 +111,24 @@ export function Chat() {
   }, [selectedModel]);
 
   return (
-    <Card className="flex h-[clamp(300px,70vh,700px)] w-[clamp(260px,60vw,700px)] flex-col">
+    <Card className="flex h-[calc(100dvh-165px)] w-[clamp(260px,60vw,1000px)] flex-col rounded-2xl">
       <CardHeader className="h-18 flex flex-row items-center py-3">
         <div className="flex-1">
-          <p className="font-bold leading-none tracking-tight">ChatGPT</p>
+          <p className="text-lg font-bold leading-none tracking-tight">
+            ChatGPT
+          </p>
         </div>
         <ModelSelector
           selectedModel={selectedModel}
           onModelChange={handleModelChange}
         />
       </CardHeader>
-      <CardContent className="grow overflow-y-auto">
+      <CardContent className="flex grow flex-col-reverse overflow-y-auto">
         <div className="space-y-4">
           {messages.map((message) => (
             <div
               key={message.id}
-              className={`flex w-max max-w-[75%] flex-col gap-2 whitespace-pre-wrap rounded-lg px-3 py-2 text-sm ${
+              className={`flex w-max max-w-[75%] flex-col gap-2 whitespace-pre-wrap rounded-lg px-3 py-2 ${
                 message.role === 'user'
                   ? 'ml-auto bg-primary text-primary-foreground'
                   : 'bg-muted'

--- a/src/components/ChatUI.tsx
+++ b/src/components/ChatUI.tsx
@@ -119,8 +119,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
         type="submit"
         size="icon"
         variant="secondary"
-        className="absolute bottom-3.5 right-3 size-8">
-        <PaperPlaneIcon className="h-4 w-4" />
+        className="absolute bottom-3 right-3">
+        <PaperPlaneIcon className="size-[17px]" />
         <span className="sr-only">Send</span>
       </Button>
     </form>

--- a/src/components/ChatUI.tsx
+++ b/src/components/ChatUI.tsx
@@ -9,12 +9,30 @@ import {
   SelectTrigger,
   SelectValue,
   SelectContent,
+  SelectSeparator,
   SelectGroup,
   SelectLabel,
   SelectItem,
 } from '@components/ui/select';
 
 import { useChat, type UseChatHelpers, type UseChatOptions } from 'ai/react';
+
+const modelGroups = [
+  {
+    label: 'OpenAI',
+    models: [
+      { label: 'GPT-3.5-Turbo', value: 'gpt-3.5-turbo' },
+      { label: 'GPT-4-Turbo', value: 'gpt-4-turbo' },
+    ],
+  },
+  {
+    label: 'OpenAI Legacy',
+    models: [
+      { label: 'GPT-3.5-Turbo-0613', value: 'gpt-3.5-turbo-0613' },
+      { label: 'GPT-4-0613', value: 'gpt-4-0613' },
+    ],
+  },
+];
 
 interface ModelSelectorProps {
   selectedModel: string;
@@ -35,11 +53,21 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
         <SelectValue placeholder="Select a model" />
       </SelectTrigger>
       <SelectContent>
-        <SelectGroup>
-          <SelectLabel className="text-xs">OpenAI</SelectLabel>
-          <SelectItem value="gpt-3.5-turbo">GPT-3.5</SelectItem>
-          <SelectItem value="gpt-4">GPT-4-Turbo</SelectItem>
-        </SelectGroup>
+        {modelGroups.map((group, index) => (
+          <SelectGroup key={index}>
+            <SelectLabel className="text-sm font-bold tracking-wide text-foreground">
+              {group.label}
+            </SelectLabel>
+            {group.models.map((item) => (
+              <SelectItem
+                className="text-muted-foreground data-[state=checked]:text-foreground"
+                value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+            {index < modelGroups.length - 1 && <SelectSeparator />}
+          </SelectGroup>
+        ))}
       </SelectContent>
     </Select>
   );
@@ -49,13 +77,12 @@ export function Chat() {
   const defaultModel: string = 'gpt-3.5-turbo';
   const localStorageAvailable =
     typeof window !== 'undefined' && window.localStorage;
-  
+
   const model = localStorageAvailable
     ? localStorage.getItem('selectedModel') || defaultModel
     : defaultModel;
 
-  const [selectedModel, setSelectedModel] =
-    React.useState<string>(model);
+  const [selectedModel, setSelectedModel] = React.useState<string>(model);
 
   const chatOptions: UseChatOptions = {
     api: '/api/chatRoute',
@@ -99,7 +126,7 @@ export function Chat() {
           {messages.map((message) => (
             <div
               key={message.id}
-              className={`flex w-max max-w-[75%] whitespace-pre-wrap flex-col gap-2 rounded-lg px-3 py-2 text-sm ${
+              className={`flex w-max max-w-[75%] flex-col gap-2 whitespace-pre-wrap rounded-lg px-3 py-2 text-sm ${
                 message.role === 'user'
                   ? 'ml-auto bg-primary text-primary-foreground'
                   : 'bg-muted'

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ const name = 'Bassim';
 ---
 
 <div
-  class="footer-container mt-24 pb-4 flex w-[calc(100%-32px)] sm:px-4 md:px-8">
+  class="footer-container mt-8 pb-4 flex w-[calc(100%-32px)] sm:px-4 md:px-8">
   <footer
     class="m-3 flex w-full items-center justify-between gap-4 text-sm text-muted-foreground/90">
     <div class="flex gap-4">

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/hooks/useModel.tsx
+++ b/src/hooks/useModel.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+export const useModel = (defaultModel: string) => {
+  const localStorageAvailable = typeof window !== 'undefined' && window.localStorage;
+  const [selectedModel, setSelectedModel] = useState<string>(() => {
+    if (localStorageAvailable) {
+      return localStorage.getItem('selectedModel') || defaultModel;
+    }
+
+    return defaultModel;
+  });
+
+  const handleModelChange = (model: string) => {
+    setSelectedModel(model);
+
+    if (localStorageAvailable) {
+      localStorage.setItem('selectedModel', model);
+    }
+  };
+
+  useEffect(() => {
+    const sendModelName = async () => {
+      await fetch('/api/chatRoute', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          modelName: selectedModel
+        })
+      });
+    };
+
+    sendModelName();
+  }, [selectedModel]);
+  return {
+    selectedModel,
+    handleModelChange
+  };
+};
+  


### PR DESCRIPTION
* Decrease `Footer.astro` `margin-top` to `mt-8` to match header's `margin-bottom`
- **Create array of model groups and options, OpenAI and OpenAI Legacy**
* **Update text colors, add separator between model groups**
- **major refactor: improve `ChatUI` styling and structure**
  - Add key to group.model `SelectItems`
  - Extract form to it's own `ChatInput` component and use in 
`Chat()`
  - Extract model selection logic to `useModel` hook
  - Use shadcn textarea instead of input element for chat input form
  - Change button styling and position absolutely inside textarea
  - Set outline ring to `ring-accent/20`


* **redesign: `ChatUI` component**
  - Make height full using `calc(100dvh-165px)` 
  - Use flex-col-reverse to add new messages to bottom of container instead of top. This not only looks more appropriate, it **enables autoscrolling functionality without any additional JS**
  - Make `Card` more rounded - `rounded-2xl`
  - Update chat card heading size
  - Make message text larger `1rem`