### PR TITLE
Refactor form submission logic, replace deprecated `onKeyPress`

### DIFF
--- a/src/components/ChatUI.tsx
+++ b/src/components/ChatUI.tsx
@@ -87,10 +87,14 @@ const ChatInput: React.FC<ChatInputProps> = ({
   input,
   handleInputChange,
 }) => {
-  const handleKeyPress = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const formRef = React.useRef<HTMLFormElement>(null);
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
-      handleSubmit(event);
+      if (formRef.current) {
+        formRef.current.requestSubmit();
+      }
     }
   };
 
@@ -102,7 +106,10 @@ const ChatInput: React.FC<ChatInputProps> = ({
   }, [input]);
 
   return (
-    <form onSubmit={handleSubmit} className="relative flex w-full items-center">
+    <form
+      onSubmit={handleSubmit}
+      ref={formRef}
+      className="relative flex w-full items-center">
       <Textarea
         ref={textareaRef}
         id="input"
@@ -113,7 +120,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
         autoComplete="off"
         value={input}
         onChange={handleInputChange}
-        onKeyPress={handleKeyPress}
+        onKeyDown={handleKeyDown}
       />
       <Button
         type="submit"

--- a/src/components/ChatUI.tsx
+++ b/src/components/ChatUI.tsx
@@ -75,11 +75,12 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({
 };
 
 interface ChatInputProps {
-  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  handleSubmit: UseChatHelpers['handleSubmit'];
+  handleInputChange: UseChatHelpers['handleInputChange'];
+  input: UseChatHelpers['input'];
   textareaRef: React.RefObject<HTMLTextAreaElement>;
-  input: string;
-  handleInputChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
+
 
 const ChatInput: React.FC<ChatInputProps> = ({
   handleSubmit,


### PR DESCRIPTION
Refactor form submission logic, replace deprecated `onKeyPress`

Refactored the form submission logic to use `useRef` and `requestSubmit()` method
- Uses useRef to access the form DOM element directly, aligning with React's best practices for controlled component interactions and minimizing direct DOM manipulations.
- Enhances the maintainability of the code by using modern React features and improving the form submission process.

Also replaceS the deprecated `onKeyPress` event with `onKeyDown`

Correct types to use `UseChatHelpers` type in `ChatInputProps`

Correctly uses types from Vercel AI-SDK for `handleSubmit`, `handleInputChange`, and `input` props