### PR TITLE
feat(`ChatUI`): Add stop function to cancel GPT response

### DIFF
--- a/src/components/ChatUI/Chat.tsx
+++ b/src/components/ChatUI/Chat.tsx
@@ -19,15 +19,16 @@ export const Chat: React.FC = () => {
     handleInputChange,
     handleSubmit,
     isLoading,
+    stop,
   }: UseChatHelpers = useChat(chatOptions);
 
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 
   return (
-    <Card className="flex min-h-72 min-w-64 h-full max-h-[calc(100dvh-12rem)] max-lg:w-[calc(100dvw-4rem)] flex-col rounded-2xl lg:w-[clamp(600px,60vw,1000px)]">
+    <Card className="flex h-full max-h-[calc(100dvh-12rem)] min-h-72 min-w-64 flex-col rounded-2xl max-lg:w-[calc(100dvw-4rem)] lg:w-[clamp(600px,60vw,1000px)]">
       <CardHeader className="h-18 flex flex-row items-center py-3">
         <div className="flex-1">
-          <p className="text-lg hidden xs:block font-bold leading-none tracking-tight">
+          <p className="hidden text-lg font-bold leading-none tracking-tight xs:block">
             ChatGPT
           </p>
         </div>
@@ -54,6 +55,7 @@ export const Chat: React.FC = () => {
       <CardFooter className="mt-6 ">
         <ChatInput
           isLoading={isLoading}
+          stop={stop}
           handleSubmit={handleSubmit}
           textareaRef={textareaRef}
           input={input}

--- a/src/components/ChatUI/ChatInput.tsx
+++ b/src/components/ChatUI/ChatInput.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { PaperPlaneIcon } from '@radix-ui/react-icons';
+import { Square } from 'lucide-react';
 import { Button } from '@components/ui/button';
 import { Textarea } from '@components/ui/textarea';
 import { type UseChatHelpers } from 'ai/react';
@@ -9,7 +10,8 @@ interface ChatInputProps {
   handleSubmit: UseChatHelpers['handleSubmit'];
   handleInputChange: UseChatHelpers['handleInputChange'];
   input: UseChatHelpers['input'];
-  isLoading?: UseChatHelpers['isLoading'];
+  isLoading: UseChatHelpers['isLoading'];
+  stop: UseChatHelpers['stop'];
   textareaRef: React.RefObject<HTMLTextAreaElement>;
 }
 export const ChatInput: React.FC<ChatInputProps> = ({
@@ -17,9 +19,10 @@ export const ChatInput: React.FC<ChatInputProps> = ({
   textareaRef,
   input,
   isLoading,
+  stop,
   handleInputChange,
 }) => {
-  const disabled = isLoading || input.length === 0;
+  const disabled = !isLoading && input.length === 0;
   const formRef = React.useRef<HTMLFormElement>(null);
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
@@ -57,8 +60,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         size="icon"
         variant="secondary"
         disabled={disabled}
-        className={cn('absolute bottom-3 right-3 duration-200 ease-out')}>
-        <PaperPlaneIcon className="size-[17px] transition-colors duration-200 ease-out" />
+        onClick={isLoading ? stop : undefined}
+        className={cn(
+          'absolute bottom-3 right-3 transition-colors duration-200 ease-out [&_svg]:size-[17px]'
+        )}>
+        {isLoading ? <Square /> : <PaperPlaneIcon />}
         <span className="sr-only">Send</span>
       </Button>
     </form>

--- a/src/pages/api/chatRoute.ts
+++ b/src/pages/api/chatRoute.ts
@@ -18,7 +18,6 @@ export async function POST(context: APIContext) {
   if (newModelName) {
     modelName = newModelName;
     return new Response(null, { status: 200 });
-    console.log(modelName);
   }
 
   const openai = createOpenAI({


### PR DESCRIPTION
- feat(`ChatUI`): Add stop function to cancel GPT response
  - Uses the `stop` function from the `useChat` hook to stop the GPT response when the stop icon is clicked
  - Conditionally renders the stop icon in place of the send icon when model `isLoading`
  - Update `const disabled` to only disable submit/stop button when input is empty && model is not loading

* chore(`ChatRoute.tsx`): Remove unreachable `console.log(modelName)`