### PR TITLE
fix(shiki): Create transformer to remove tabindex from pre elements

### DIFF
--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -3,6 +3,7 @@ import { codeToHtml, type BundledLanguage, type BundledTheme } from 'shiki';
 import parse from 'html-react-parser';
 import type { Element } from 'hast';
 import { isInlineCode } from '@utils/isInlineCode';
+import { removeTabIndexFromPre } from '@utils/shikiTransformers';
 
 interface CodeHighlightProps {
   className?: string;
@@ -30,6 +31,7 @@ export const CodeHighlight = ({
       codeToHtml(code, {
         lang: language as BundledLanguage,
         theme,
+        transformers: [removeTabIndexFromPre],
       }).then((html) => setHighlightedCode(parse(html)));
     }
   }, [code]);

--- a/src/utils/shikiTransformers.ts
+++ b/src/utils/shikiTransformers.ts
@@ -1,0 +1,7 @@
+import type { Element } from 'hast';
+
+export const removeTabIndexFromPre = {
+  pre(node: Element) {
+    node.properties.tabindex = '-1';
+  },
+};


### PR DESCRIPTION
- Create `shikiTransformers.ts` with `removeTabIndexFromPre` transformer
- Passes `node` prop to `pre()` transformer hook to set the tabindex to -1 on shiki generated pre elements