### PR TITLE
refactor(chat-api): Rename `chatRoute.ts` to `chat.ts`

### DIFF
--- a/src/components/ChatUI/ChatBox.tsx
+++ b/src/components/ChatUI/ChatBox.tsx
@@ -11,10 +11,6 @@ export const ChatBox: React.FC = () => {
   const defaultModel = 'gpt-3.5-turbo';
   const { selectedModel, handleModelChange } = useModel(defaultModel);
 
-  const chatOptions: UseChatOptions = {
-    api: '/api/chatRoute',
-  };
-
   const {
     messages,
     input,
@@ -22,7 +18,7 @@ export const ChatBox: React.FC = () => {
     handleSubmit,
     isLoading,
     stop,
-  }: UseChatHelpers = useChat(chatOptions);
+  }: UseChatHelpers = useChat();
 
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
 

--- a/src/hooks/useModel.tsx
+++ b/src/hooks/useModel.tsx
@@ -20,7 +20,7 @@ export const useModel = (defaultModel: string) => {
 
   useEffect(() => {
     const sendModelName = async () => {
-      await fetch('/api/chatRoute', {
+      await fetch('/api/chat', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -26,7 +26,7 @@ export async function POST(context: APIContext) {
   });
 
   const result = await streamText({
-    model: openai(modelName),
+    model: openai(modelName || 'gpt-3.5-turbo'),
     system: 'You are a helpful assistant.',
     messages,
     onFinish: ({ finishReason, usage }) => {


### PR DESCRIPTION
- `chatBox.tsx`: Remove `chatOptions` api setting because `useChat()` automatically uses `/api/chat` as default path
- `useModel.tsx`: Update POST path with new name
- `chat.ts`: Update openai provider's model argument to `openai(modelName || 'gpt-3.5-turbo')` to avoid no model error when `modelName` is not available