### PR TITLE
refactor(chat-model-state): Move chat model selection state and logic down to `ModelSelector`

### DIFF
--- a/src/components/ChatUI/ChatBox.tsx
+++ b/src/components/ChatUI/ChatBox.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import { Card, CardContent, CardFooter, CardHeader } from '@components/ui/card';
-import { useChat, type UseChatHelpers, type UseChatOptions } from '@ai-sdk/react';
-import { useModel } from '@hooks/useModel';
+import {
+  useChat,
+  type UseChatHelpers,
+} from '@ai-sdk/react';
 import { ChatInput } from './ChatInput';
 import { ModelSelector } from './ModelSelector';
 import { Messages } from './Messages';
 import { cn } from '@/lib/utils';
 
 export const ChatBox: React.FC = () => {
-  const defaultModel = 'gpt-3.5-turbo';
-  const { selectedModel, handleModelChange } = useModel(defaultModel);
-
   const {
     messages,
     input,
@@ -38,10 +37,7 @@ export const ChatBox: React.FC = () => {
       )}>
       <CardHeader className="h-18 flex flex-row items-center justify-between py-3">
         <span className={styles.headerText}>ChatGPT</span>
-        <ModelSelector
-          selectedModel={selectedModel}
-          onModelChange={handleModelChange}
-        />
+        <ModelSelector />
       </CardHeader>
       <CardContent className="flex flex-col-reverse overflow-y-auto pb-0 pt-2">
         <Messages messages={messages} />

--- a/src/components/ChatUI/ModelSelector.tsx
+++ b/src/components/ChatUI/ModelSelector.tsx
@@ -9,6 +9,7 @@ import {
   SelectLabel,
   SelectItem,
 } from '@components/ui/select';
+import { useModel } from '@hooks/useModel';
 
 const modelGroups = [
   {
@@ -27,21 +28,14 @@ const modelGroups = [
     ],
   },
 ];
-interface ModelSelectorProps {
-  selectedModel: string;
-  onModelChange: (model: string) => void;
-}
-export const ModelSelector: React.FC<ModelSelectorProps> = ({
-  selectedModel,
-  onModelChange,
-}) => {
-  const handleModelChange = (value: string) => {
-    onModelChange(value);
-  };
+
+export const ModelSelector = () => {
+  const defaultModel = 'gpt-3.5-turbo';
+  const { selectedModel, handleModelChange } = useModel(defaultModel);
 
   return (
     <Select value={selectedModel} onValueChange={handleModelChange}>
-      <SelectTrigger className="w-full xs:w-[180px] focus:ring-ring/20">
+      <SelectTrigger className="w-full focus:ring-ring/20 xs:w-[180px]">
         <SelectValue placeholder="Select a model" />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
- Model selection state is separate from `ChatBox` logic so it's been moved down to the `ModelSelector` component.