### PR TITLE
refactor(CommandMenu): Modularize and update prop name

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -25,12 +25,26 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import type { CollectionEntry } from 'astro:content';
 type PostsType = CollectionEntry<'posts'>[];
 
-type CommandMenuProps = {
-  buttonStyles?: string;
-  posts?: PostsType;
+const SettingsGroup = () => {
+  const { toggleTheme } = useThemeToggle();
+  return (
+    <CommandGroup heading="Settings">
+      <CommandItem onSelect={toggleTheme}>
+        <ThemeIcon />
+        <span className="ml-2">Toggle theme</span>
+        <CommandShortcut>T</CommandShortcut>
+      </CommandItem>
+    </CommandGroup>
+  );
 };
 
-export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
+export function CommandMenu({
+  buttonStyles,
+  sortedPosts,
+}: {
+  buttonStyles?: string;
+  sortedPosts?: PostsType;
+}) {
   const [open, setOpen] = React.useState(false);
   const { toggleTheme } = useThemeToggle();
   
@@ -88,8 +102,8 @@ export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
             ))}
           </CommandGroup>
           <CommandSeparator />
-          <CommandGroup heading="Blog Posts">
-            {posts?.map((post) => (
+          <CommandGroup heading="Blog posts">
+            {sortedPosts?.map((post) => (
               <CommandItem
                 slot="blogPosts"
                 key={post.data.title}
@@ -109,12 +123,7 @@ export function CommandMenu({ buttonStyles, posts }: CommandMenuProps) {
             ))}
           </CommandGroup>
           <CommandSeparator />
-          <CommandGroup heading="Settings">
-            <CommandItem onSelect={toggleTheme}>
-              <ThemeIcon />
-              <span className="ml-2">Toggle theme</span>
-            </CommandItem>
-          </CommandGroup>
+          <SettingsGroup />
         </CommandList>
       </CommandDialog>
     </>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -41,7 +41,7 @@ import { isActiveLink } from '@utils/isActiveLink';
       </span>
     </nav>
     <span class="flex items-center gap-2">
-      <CommandMenu client:load posts={sortedBlogPosts} />
+      <CommandMenu client:load sortedPosts={sortedBlogPosts} />
       <AccentColorSelector client:load />
       <SideMenu client:load />
       <ModeToggle client:load />


### PR DESCRIPTION
- Update the `posts` prop name to `sortedPosts`, update in `header.astro`
- Refactor `CommandMenu`
  - Separate settings group to its own component, call theme hook within it.
  - Use arrow functions for components and integrate type interface directly in the component.