### PR TITLE
fix(image-handler): Use new exported `getImage()` function in `MDLayout`

### DIFF
--- a/src/layouts/MDLayout.astro
+++ b/src/layouts/MDLayout.astro
@@ -4,7 +4,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import Prose from '@components/Prose.astro';
 import { TableOfContents } from '@components/TableOfContents';
 import { formatDate } from '@utils/formatDate';
-import { images } from '@utils/imageHandler';
+import { getImage } from '@utils/imageHandler';
 import { generateJsonLd } from '@utils/generateBlogSchema';
 import type { CollectionEntry } from 'astro:content';
 
@@ -16,18 +16,19 @@ type Props = {
 const { data, headings } = Astro.props;
 
 const schema = generateJsonLd(data, Astro.request.url);
+const image = data.image ? await getImage(data.image.url) : undefined;
 ---
 
 <BaseLayout {...data}>
-  <script is:inline slot="head" type="application/ld+json" set:html={schema} />
+  <script is:inline slot='head' type='application/ld+json' set:html={schema} />
   <div
-    class="grid grid-cols-1 justify-center lg:grid-cols-[1fr_240px] 2xl:grid-cols-[240px_1fr_240px]">
-    <div class="hidden 2xl:block"></div>
-    <article class="mx-6 xs:mx-10">
+    class='grid grid-cols-1 justify-center lg:grid-cols-[1fr_240px] 2xl:grid-cols-[240px_1fr_240px]'>
+    <div class='hidden 2xl:block'></div>
+    <article class='mx-6 xs:mx-10'>
       <Prose>
-        <div class="mb-1 flex justify-start">
+        <div class='mb-1 flex justify-start'>
           <span
-            class="written-by max-w-fit rounded-md bg-accent-300/25 px-2 py-1 text-sm text-accent-500 dark:bg-accent-700/25 dark:text-accent-400">
+            class='written-by max-w-fit rounded-md bg-accent-300/25 px-2 py-1 text-sm text-accent-500 dark:bg-accent-700/25 dark:text-accent-400'>
             Written by {data.author} on
             <time>
               {formatDate(data.pubDate, { weekday: 'long' })}
@@ -36,11 +37,11 @@ const schema = generateJsonLd(data, Astro.request.url);
         </div>
         <h1>{data.title}</h1>
         {
-          data.image && (
+          data.image && image && (
             <Image
-              src={images[data.image.url]()}
-              width={data.image.width}
-              height={data.image.height}
+              src={image}
+              width={image.width}
+              height={image.height}
               alt={data.image.alt}
             />
           )
@@ -50,7 +51,7 @@ const schema = generateJsonLd(data, Astro.request.url);
       </Prose>
     </article>
     <div
-      class="hidden min-h-full prose-a:transition-colors prose-a:duration-100 lg:block">
+      class='hidden min-h-full prose-a:transition-colors prose-a:duration-100 lg:block'>
       <TableOfContents headings={headings} />
     </div>
   </div>


### PR DESCRIPTION
Instead of exporting the imported images promise and using it directly in the `Image` component's `src` attribute, use `getImage()`, passing `data.image.url` to return the image object.