### PR TITLE
feat(chat-model): Add OpenAI GPT-4o-mini, set as default

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -3,7 +3,7 @@ semi: true
 bracketSameLine: true
 printWidth: 80
 singleQuote: true
-jsxSingleQuote: true
+jsxSingleQuote: false
 trailingComma: "es5"
 tailwindAttributes:
   - Classes

--- a/biome.json
+++ b/biome.json
@@ -38,14 +38,14 @@
     }
   },
   "formatter": {
-    "enabled": false,
+    "enabled": true,
     "indentStyle": "space",
     "formatWithErrors": true
   },
   "javascript": {
     "formatter": {
       "quoteStyle": "single",
-      "jsxQuoteStyle": "single",
+      "jsxQuoteStyle": "double",
       "trailingCommas": "es5",
       "bracketSameLine": true
     }

--- a/src/components/ChatUI/ModelSelector.tsx
+++ b/src/components/ChatUI/ModelSelector.tsx
@@ -30,7 +30,6 @@ const modelGroups = [
 ];
 
 export const ModelSelector = () => {
-  const defaultModel = 'gpt-3.5-turbo';
   const { selectedModel, handleModelChange } = useModel(defaultModel);
 
   return (

--- a/src/components/ChatUI/ModelSelector.tsx
+++ b/src/components/ChatUI/ModelSelector.tsx
@@ -29,6 +29,8 @@ const modelGroups = [
   },
 ];
 
+export const defaultModel = 'gpt-4o-mini';
+
 export const ModelSelector = () => {
   const { selectedModel, handleModelChange } = useModel(defaultModel);
 

--- a/src/components/ChatUI/ModelSelector.tsx
+++ b/src/components/ChatUI/ModelSelector.tsx
@@ -16,6 +16,7 @@ const modelGroups = [
     models: [
       { label: 'GPT-3.5-Turbo', value: 'gpt-3.5-turbo' },
       { label: 'GPT-4-Turbo', value: 'gpt-4-turbo' },
+      { label: 'GPT-4o-Mini', value: 'gpt-4o-mini' },
       { label: 'GPT-4o', value: 'gpt-4o' },
     ],
   },

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -26,7 +26,7 @@ export async function POST(context: APIContext) {
   });
 
   const result = await streamText({
-    model: openai(modelName || 'gpt-3.5-turbo'),
+    model: openai(modelName || defaultModel),
     system: 'You are a helpful assistant.',
     messages,
     onFinish: ({ finishReason, usage }) => {

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,6 +1,7 @@
 import type { APIContext } from 'astro';
 import { streamText, type CoreMessage } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
+import { defaultModel } from '@components/ChatUI/ModelSelector';
 
 export const prerender = false;
 


### PR DESCRIPTION
- feat(chat-model): Add OpenAI GPT-4o-mini, set as default
- chore(chat-model): Set default model to `gpt-4o-mini`
  - Remove redundant default model name in `chat.ts`