### PR TITLE
refactoring: Update tw dark mode strategy, and renovate + vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "[astro]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "tailwindCSS.classAttributes": ["class", "className", "class:list"],
   "tailwindCSS.experimental.classRegex": [
     ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],

--- a/renovate.json
+++ b/renovate.json
@@ -27,8 +27,8 @@
       "semanticCommitScope": "dev-deps"
     },
     {
-      "groupName": "Components, icons, and styling libraries",
-      "matchPackagePrefixes": ["@radix-ui/"],
+      "groupName": "Components, icons, fonts, and styling libraries",
+      "matchPackagePrefixes": ["@radix-ui/", "@fontsource/"],
       "matchPackageNames": ["cmdk", "lucide-react", "framer-motion"]
     },
     {
@@ -43,9 +43,9 @@
     },
     {
       "groupName": "Astro, Integrations, and Adapters",
-      "matchSourceUrls": ["https://github.com/withastro/astro"],
+      "matchSourceUrls": ["https://github.com/withastro/astro", "https://github.com/withastro/adapters/"],
       "matchPackagePrefixes": ["@astrojs/", "astro"],
-      "matchPackageNames": ["astro-icon", "sharp", "@astrojs/cloudflare"]
+      "matchPackageNames": ["astro-icon", "sharp", "@astrojs/vercel"]
     },
     {
       "groupName": "React dependencies",

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -14,7 +14,7 @@ module.exports = {
     './components/**/*.{ts,tsx}',
     './app/**/*.{ts,tsx}',
   ],
-  darkMode: 'class',
+  darkMode: 'selector',
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
config(tailwind): Update dark mode strategy to use 'selector'

- Replaces `'class'` strategy, functionally equivalent

config(vscode): Set prettier as default formatter

config(renovate): Update dependency grouping