### PR TITLE
fix: Use `setTimeout` instead of `requestAnimationFrame` to unify browser behavior

### DIFF
--- a/src/lib/utils/toggleTheme.ts
+++ b/src/lib/utils/toggleTheme.ts
@@ -1,18 +1,17 @@
+/**
+ * Disable transitions during theme toggle to prevent transitioning between
+ * light and dark mode.
+ */
 const disableTransitions = () => {
   const css = document.createElement('style');
-  css.textContent = `
-    * {
-      -webkit-transition: none !important;
-      -moz-transition: none !important;
-      -o-transition: none !important;
-      -ms-transition: none !important;
-      transition: none !important;
-    }
-  `;
+  css.textContent = `* { transition: none !important; }`;
   document.head.appendChild(css);
-  requestAnimationFrame(() => {
+
+  // setTimeout(0) schedules style removal for the next event loop,
+  // allowing the disabling styles to be applied successfully before removal
+  setTimeout(() => {
     document.head.removeChild(css);
-  });
+  }, 0);
 };
 
 export const toggleTheme = () => {


### PR DESCRIPTION
`lib/utils/toggleTheme.ts` was using `requestAnimationFrame` to schedule the removal of the transition styles. This worked well in Chrome, but in Firefox, the styles were not applied before the removal. This change uses `setTimeout` to schedule the removal of the styles, which ensures the styles are applied before removal in Firefox.

This commit also removes manual vendor prefixing, this is not needed and has been tested in all major browsers.