### PR TITLE
chore: Add Bun as packageManager to avoid accidentally running others

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,6 @@
     "prettier-plugin-tailwindcss": "0.6.5",
     "type-coverage": "2.29.1",
     "typescript": "5.5.3"
-  }
+  },
+  "packageManager": "bun@1.2.0"
 }


### PR DESCRIPTION
### TL;DR
Added Bun package manager specification to `package.json`

### What changed?
Added `"packageManager": "bun@1.2.0"` to package.json to explicitly define Bun as the project's package manager

### How to test?
1. Run a command with NPM or PNPM
2. Verify that it errors out

### Why make this change?
Ensures users cannot accidentally use other package manager commands