### PR TITLE
feat: Implement rehype inline code property

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,6 +34,9 @@
         "useFocusableInteractive": "warn",
         "noLabelWithoutControl": "warn",
         "useSemanticElements": "warn"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
       }
     }
   },

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "react-dom": "18.3.1",
         "react-hotkeys-hook": "4.5.0",
         "react-markdown": "9.0.1",
+        "react-shiki": "link:react-shiki",
         "react-syntax-highlighter": "15.5.0",
         "sharp": "0.33.4",
         "shiki": "1.9.1",
@@ -1266,6 +1267,8 @@
     "react-remove-scroll": ["react-remove-scroll@2.5.7", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.4", "react-style-singleton": "^2.2.1", "tslib": "^2.1.0", "use-callback-ref": "^1.3.0", "use-sidecar": "^1.1.2" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.6", "", { "dependencies": { "react-style-singleton": "^2.2.1", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g=="],
+
+    "react-shiki": ["react-shiki@link:react-shiki", {}],
 
     "react-style-singleton": ["react-style-singleton@2.2.1", "", { "dependencies": { "get-nonce": "^1.0.0", "invariant": "^2.2.4", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g=="],
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-dom": "18.3.1",
     "react-hotkeys-hook": "4.5.0",
     "react-markdown": "9.0.1",
+    "react-shiki": "link:react-shiki",
     "react-syntax-highlighter": "15.5.0",
     "sharp": "0.33.4",
     "shiki": "1.9.1",

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import type { Element } from 'hast';
 import { isInlineCode } from '@/lib/utils';
-import { useShikiHighlighter } from '@/lib/hooks';
+import { useShikiHighlighter } from 'react-shiki';
 import tokyoNight from '@styles/tokyo-night.mjs';
 
 interface CodeHighlightProps {

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -21,7 +21,7 @@ export const CodeHighlight = ({
   const match = className?.match(/language-(\w+)/);
   const language = match ? match[1] : undefined;
 
-  const highlightedCode = useShikiHighlighter(language, code, theme);
+  const highlightedCode = useShikiHighlighter(language, code, theme, { debounceMs: 150 });
 
   return !isInline ? (
     <div className="shiki not-prose relative [&_pre]:overflow-auto [&_pre]:rounded-lg [&_pre]:px-6 [&_pre]:py-5">

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -17,9 +17,6 @@ export const CodeHighlight = ({
   inline: inlineProp,
   ...props
 }: CodeHighlightProps) => {
-  if (!children) {
-    return null;
-  }
   const code = String(children);
   const language = className?.match(/language-(\w+)/)?.[1];
 

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -7,14 +7,19 @@ interface CodeHighlightProps {
   className?: string | undefined;
   children?: ReactNode | undefined;
   node?: Element | undefined;
+  inline?: boolean | undefined;
 }
 
 export const CodeHighlight = ({
   className,
   children,
   node,
+  inline: inlineProp,
   ...props
 }: CodeHighlightProps) => {
+  if (!children) {
+    return null;
+  }
   const code = String(children);
   const language = className?.match(/language-(\w+)/)?.[1];
 

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import type { Element } from 'hast';
 import { isInlineCode } from '@/lib/utils';
-import { useShikiHighlighter } from '@hooks/useShiki';
+import { useShikiHighlighter } from '@/lib/hooks';
 import tokyoNight from '@styles/tokyo-night.mjs';
 
 interface CodeHighlightProps {
@@ -21,8 +21,14 @@ export const CodeHighlight = ({
   const match = className?.match(/language-(\w+)/);
   const language = match ? match[1] : undefined;
 
-  const highlightedCode = useShikiHighlighter(language, code, theme, { throttleMs: 150 });
+  const highlightedCode = useShikiHighlighter(
+    language,
+    code,
+    theme,
+    { throttleMs: 150 }
+  );
 
+  // FIX: Long inline code blocks are not wrapped
   return !isInline ? (
     <div className="shiki not-prose relative [&_pre]:overflow-auto [&_pre]:rounded-lg [&_pre]:px-6 [&_pre]:py-5">
       {language ? (

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -20,8 +20,8 @@ export const CodeHighlight = ({
   const language = className?.match(/language-(\w+)/)?.[1];
 
   const highlightedCode = useShikiHighlighter(
-    language,
     code,
+    language,
     tokyoNight,
     { delay: 150 }
   );

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -23,7 +23,7 @@ export const CodeHighlight = ({
     language,
     code,
     tokyoNight,
-    { throttleMs: 150 }
+    { delay: 150 }
   );
 
   // TODO: Long inline code blocks are not wrapped

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -21,7 +21,7 @@ export const CodeHighlight = ({
   const match = className?.match(/language-(\w+)/);
   const language = match ? match[1] : undefined;
 
-  const highlightedCode = useShikiHighlighter(language, code, theme, { debounceMs: 150 });
+  const highlightedCode = useShikiHighlighter(language, code, theme, { throttleMs: 150 });
 
   return !isInline ? (
     <div className="shiki not-prose relative [&_pre]:overflow-auto [&_pre]:rounded-lg [&_pre]:px-6 [&_pre]:py-5">

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -5,9 +5,9 @@ import { useShikiHighlighter } from '@hooks/useShiki';
 import tokyoNight from '@styles/tokyo-night.mjs';
 
 interface CodeHighlightProps {
-  className: string;
-  children: ReactNode | undefined;
-  node: Element;
+  className?: string | undefined;
+  children?: ReactNode | undefined;
+  node?: Element | undefined;
 }
 
 export const CodeHighlight = ({
@@ -20,8 +20,6 @@ export const CodeHighlight = ({
   const code = String(children);
   const match = className?.match(/language-(\w+)/);
   const language = match ? match[1] : undefined;
-
-  const isInline: boolean = isInlineCode(node);
 
   const highlightedCode = useShikiHighlighter(language, code, theme);
 

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -29,7 +29,7 @@ export const CodeHighlight = ({
 
   const isInline = node && isInlineCode(node);
 
-  return !isInline ? (
+  return (!isInline || !inlineProp) ? (
     <div className="shiki not-prose relative [&_pre]:overflow-auto [&_pre]:rounded-lg [&_pre]:px-6 [&_pre]:py-5">
       {language ? (
         <span className="absolute right-3 top-2 text-xs tracking-tighter text-muted-foreground/85">

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 import type { Element } from 'hast';
-import { isInlineCode } from '@/lib/utils';
-import { useShikiHighlighter } from 'react-shiki';
+import { useShikiHighlighter, isInlineCode } from 'react-shiki';
 import tokyoNight from '@styles/tokyo-night.mjs';
 
 interface CodeHighlightProps {
@@ -26,7 +25,8 @@ export const CodeHighlight = ({
     { delay: 150 }
   );
 
-  // TODO: Long inline code blocks are not wrapped
+  const isInline = node && isInlineCode(node);
+
   return !isInline ? (
     <div className="shiki not-prose relative [&_pre]:overflow-auto [&_pre]:rounded-lg [&_pre]:px-6 [&_pre]:py-5">
       {language ? (

--- a/src/components/ChatUI/CodeHighlight.tsx
+++ b/src/components/ChatUI/CodeHighlight.tsx
@@ -16,19 +16,17 @@ export const CodeHighlight = ({
   node,
   ...props
 }: CodeHighlightProps) => {
-  const theme = customTheme;
   const code = String(children);
-  const match = className?.match(/language-(\w+)/);
-  const language = match ? match[1] : undefined;
+  const language = className?.match(/language-(\w+)/)?.[1];
 
   const highlightedCode = useShikiHighlighter(
     language,
     code,
-    theme,
+    tokyoNight,
     { throttleMs: 150 }
   );
 
-  // FIX: Long inline code blocks are not wrapped
+  // TODO: Long inline code blocks are not wrapped
   return !isInline ? (
     <div className="shiki not-prose relative [&_pre]:overflow-auto [&_pre]:rounded-lg [&_pre]:px-6 [&_pre]:py-5">
       {language ? (

--- a/src/components/ChatUI/Messages.tsx
+++ b/src/components/ChatUI/Messages.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { cn } from '@/lib/utils';
 import { CodeHighlight } from './CodeHighlight';
+import { rehypeInlineCodeProperty } from '@/lib/utils/isInlineCode';
 import type { Message } from '@ai-sdk/react';
 
 const baseMessageStyles: string =
@@ -19,7 +20,10 @@ const messageStyles: Record<string, Array<string>> = {
 
 const RenderedMessage = React.memo(({ message }: { message: Message }) => (
   <div className={cn(messageStyles[message.role])}>
-    <ReactMarkdown components={{ code: CodeHighlight }}>
+    <ReactMarkdown
+      components={{ code: CodeHighlight }}
+      rehypePlugins={[rehypeInlineCodeProperty]}
+    >
       {message.content}
     </ReactMarkdown>
   </div>

--- a/src/components/ChatUI/Messages.tsx
+++ b/src/components/ChatUI/Messages.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { cn } from '@/lib/utils';
 import { CodeHighlight } from './CodeHighlight';
-import { rehypeInlineCodeProperty } from '@/lib/utils/isInlineCode';
+import { rehypeInlineCodeProperty } from 'react-shiki';
 import type { Message } from '@ai-sdk/react';
 
 const baseMessageStyles: string =

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useShiki';

--- a/src/lib/hooks/useShiki.ts
+++ b/src/lib/hooks/useShiki.ts
@@ -85,26 +85,33 @@ export const useShikiHighlighter = (
     let isMounted = true;
 
     const performHighlight = async () => {
+      let highlightedCode: ReactNode | string;
+
       try {
         const highlighter = await makeHighlighter(lang, theme);
-
         const html = highlighter.codeToHtml(code, {
           lang,
           theme: theme.name,
           transformers: [removeTabIndexFromPre],
         });
-
-        if (isMounted) {
-          setHighlightedCode(parse(html || code));
-        }
+        highlightedCode = parse(html);
       } catch (error) {
-        if (isMounted) {
-          console.error('Error highlighting code:', error);
-          setHighlightedCode(code);
-        }
+        console.error('Error highlighting code:', error);
+        const highlighter = await makeHighlighter('plaintext', theme);
+
+        const plainText = highlighter.codeToHtml(code, {
+          lang: 'plaintext',
+          theme: theme.name,
+          transformers: [removeTabIndexFromPre]
+        });
+        highlightedCode = parse(plainText);
+      }
+
+      // Update state only if we're still mounted
+      if (isMounted) {
+        setHighlightedCode(highlightedCode);
       }
     };
-
 
     const executeHighlight = () => {
       const { throttleMs } = options;

--- a/src/lib/hooks/useShiki.ts
+++ b/src/lib/hooks/useShiki.ts
@@ -10,17 +10,17 @@ import { removeTabIndexFromPre } from '@/lib/utils';
 type HexColor = string;
 
 type CustomTheme = {
-    name: string;
-    displayName: string;
-    colors: Record<string, HexColor>;
-    tokenColors: {
-      scope: string | string[];
-      settings: {
-        fontStyle?: string;
-        foreground?: HexColor;
-      };
-    }[];
-  };
+  name: string;
+  displayName: string;
+  colors: Record<string, HexColor>;
+  tokenColors: {
+    scope: string | string[];
+    settings: {
+      fontStyle?: string;
+      foreground?: HexColor;
+    };
+  }[];
+};
 
 // Store all created highlighter instances
 const highlighters = new Map<BundledLanguage, Promise<Highlighter>>();
@@ -35,8 +35,6 @@ export const useShikiHighlighter = (
   );
 
   useEffect(() => {
-    if (!lang) return;
-
     const highlight = async () => {
       if (!highlighters.has(lang)) {
         // Create a new highlighter for this language

--- a/src/lib/hooks/useShiki.ts
+++ b/src/lib/hooks/useShiki.ts
@@ -91,8 +91,13 @@ export const useShikiHighlighter = (
 
   useEffect(() => {
     const performHighlight = async () => {
-      const highlighter = await getOrCreateHighlighter(lang, theme);
-      setHighlightedCode(convertCodeToHtml(highlighter, code, lang, theme));
+      try {
+        const highlighter = await getOrCreateHighlighter(lang, theme);
+        setHighlightedCode(convertCodeToHtml(highlighter, code, lang, theme));
+      } catch (error) {
+        console.error('Error highlighting code:', error);
+        setHighlightedCode(code);
+      }
     };
 
     const executeHighlight = () => {

--- a/src/lib/hooks/useShiki/index.ts
+++ b/src/lib/hooks/useShiki/index.ts
@@ -69,8 +69,8 @@ const throttleHighlighting = (
 };
 
 export const useShikiHighlighter = (
-  lang: Language,
   code: string,
+  lang: Language,
   theme: Theme,
   options: HighlighterOptions = {}
 ) => {

--- a/src/lib/hooks/useShiki/types.ts
+++ b/src/lib/hooks/useShiki/types.ts
@@ -1,30 +1,43 @@
-import type { BundledLanguage } from 'shiki';
+import type { BundledLanguage, BundledTheme, ThemeRegistration } from 'shiki';
 
-type HexColor = string;
+/** 
+ * Languages for syntax highlighting.
+ * @see https://shiki.style/languages
+ */
 
-// Language can only be a BundledLanguage or plaintext, we define string to suppor
-type Language = BundledLanguage | string | undefined | { id: string };
+// `string & {}` allows any string while preserving 
+// union with other types for autocomplete
+type Language =
+  BundledLanguage
+  | "plaintext"
+  | (string & {})
+  | undefined;
 
-// TODO: Add support for multiple themes
-type CustomTheme = {
-  name: string;
-  displayName: string;
-  colors: Record<string, HexColor>;
-  tokenColors: {
-    scope: string | string[];
-    settings: {
-      fontStyle?: string;
-      foreground?: HexColor;
-    };
-  }[];
-};
+/**
+ * A textmate theme object or a Shiki BundledTheme
+ * @see https://shiki.style/themes
+ */
+type Theme = ThemeRegistration | BundledTheme;
 
+/**
+ * Configuration options for the syntax highlighter
+ */
 type HighlighterOptions = {
+  /** 
+   * Minimum time (in milliseconds) between highlight operations. 
+   * Defaults to undefined (no throttling)
+   */
   throttleMs?: number;
 };
 
+/**
+ * State for the throttling logic
+ */
 type ThrottleState = {
+  /** 
+   * Timestamp of the last highlight operation in milliseconds 
+   * */
   lastHighlightTime: number;
 };
 
-export type { CustomTheme, Language, HighlighterOptions, ThrottleState };
+export type { Language, Theme, HighlighterOptions, ThrottleState };

--- a/src/lib/hooks/useShiki/types.ts
+++ b/src/lib/hooks/useShiki/types.ts
@@ -27,17 +27,21 @@ type HighlighterOptions = {
    * Minimum time (in milliseconds) between highlight operations. 
    * Defaults to undefined (no throttling)
    */
-  throttleMs?: number;
+  delay?: number;
 };
 
 /**
  * State for the throttling logic
  */
-type ThrottleState = {
-  /** 
-   * Timestamp of the last highlight operation in milliseconds 
-   * */
-  lastHighlightTime: number;
+type TimeoutState = {
+  /**
+   * Id of the timeout that is currently scheduled
+   */
+  timeoutId: NodeJS.Timeout | undefined;
+  /**
+   * Next time when the timeout can be scheduled
+   */
+  nextAllowedTime: number;
 };
 
-export type { Language, Theme, HighlighterOptions, ThrottleState };
+export type { Language, Theme, HighlighterOptions, TimeoutState };

--- a/src/lib/hooks/useShiki/types.ts
+++ b/src/lib/hooks/useShiki/types.ts
@@ -1,0 +1,30 @@
+import type { BundledLanguage } from 'shiki';
+
+type HexColor = string;
+
+// Language can only be a BundledLanguage or plaintext, we define string to suppor
+type Language = BundledLanguage | string | undefined | { id: string };
+
+// TODO: Add support for multiple themes
+type CustomTheme = {
+  name: string;
+  displayName: string;
+  colors: Record<string, HexColor>;
+  tokenColors: {
+    scope: string | string[];
+    settings: {
+      fontStyle?: string;
+      foreground?: HexColor;
+    };
+  }[];
+};
+
+type HighlighterOptions = {
+  throttleMs?: number;
+};
+
+type ThrottleState = {
+  lastHighlightTime: number;
+};
+
+export type { CustomTheme, Language, HighlighterOptions, ThrottleState };

--- a/src/lib/utils/isInlineCode.ts
+++ b/src/lib/utils/isInlineCode.ts
@@ -1,29 +1,46 @@
-import type { Element, Root, Parent } from 'hast';
+import type { Element, Root } from 'hast';
 import { visit } from 'unist-util-visit';
 
-export const isInlineCode = (node: Element): boolean => {
-  return node.position?.start.line === node.position?.end.line;
-};
+/**
+ * This augmentation ensures that hast.RootData includes the same
+ * index signature as unist.Data, preventing type incompatibilities
+ * when we pass a hast.Root to unist-util-visit (which expects Node<Data>).
+ */
+declare module 'hast' {
+  interface RootData {
+    [key: string]: unknown;
+  }
+}
 
 
+/**
+ * Rehype plugin to add an 'inline' property to <code> elements.
+ * Sets an 'inline' property to true if the <code> is not within a <pre> tag.
+ *
+ * Pass this plugin to the `rehypePlugins` prop of ReactMarkdown.
+ * You can then access `inline` as a prop from ReactMarkdown.
+ *
+ * @example
+ * import { rehypeInlineCodeProperty } from 'react-shiki';
+ * <ReactMarkdown rehypePlugins={[rehypeInlineCodeProperty]} />
+ */
 export function rehypeInlineCodeProperty() {
-  return function (tree: Root) {
-    visit(tree as any, 'element', function (node: Element, _index, parent: Parent | null) {
-      if (node.tagName === 'code') {
-        // Ensure properties exist
-        node.properties = node.properties || {};
-
-        // Check if the parent is a pre tag
-        const isInPre = parent && 'tagName' in parent && parent.tagName === 'pre';
-
-        // Set inline property
-        node.properties.inline = !isInPre;
-
-        console.log('Processing code node:', {
-          parentTag: isInPre ? 'pre' : parent?.type,
-          inline: node.properties.inline
-        });
+  return function (tree: Root): undefined {
+    visit(tree, 'element', function (node: Element, _index, parent: Element) {
+      if (parent && parent.tagName === 'pre') {
+        node.properties.inline = false;
+      } else {
+        node.properties.inline = true;
       }
     });
   }
 }
+
+
+/**
+ * Innacurate way to determine if code is inline.
+ * Reports `inline = false` for multiline inline code blocks.
+ */
+export const isInlineCode = (node: Element): boolean => {
+  return node.position?.start.line === node.position?.end.line;
+};

--- a/src/lib/utils/isInlineCode.ts
+++ b/src/lib/utils/isInlineCode.ts
@@ -1,5 +1,29 @@
-import type { Element } from 'hast';
+import type { Element, Root, Parent } from 'hast';
+import { visit } from 'unist-util-visit';
 
 export const isInlineCode = (node: Element): boolean => {
   return node.position?.start.line === node.position?.end.line;
 };
+
+
+export function rehypeInlineCodeProperty() {
+  return function (tree: Root) {
+    visit(tree as any, 'element', function (node: Element, _index, parent: Parent | null) {
+      if (node.tagName === 'code') {
+        // Ensure properties exist
+        node.properties = node.properties || {};
+
+        // Check if the parent is a pre tag
+        const isInPre = parent && 'tagName' in parent && parent.tagName === 'pre';
+
+        // Set inline property
+        node.properties.inline = !isInPre;
+
+        console.log('Processing code node:', {
+          parentTag: isInPre ? 'pre' : parent?.type,
+          inline: node.properties.inline
+        });
+      }
+    });
+  }
+}

--- a/src/lib/utils/isInlineCode.ts
+++ b/src/lib/utils/isInlineCode.ts
@@ -21,6 +21,7 @@ declare module 'hast' {
  * You can then access `inline` as a prop from ReactMarkdown.
  *
  * @example
+ * import ReactMarkdown from 'react-markdown';
  * import { rehypeInlineCodeProperty } from 'react-shiki';
  * <ReactMarkdown rehypePlugins={[rehypeInlineCodeProperty]} />
  */

--- a/src/lib/utils/shikiTransformers.ts
+++ b/src/lib/utils/shikiTransformers.ts
@@ -1,7 +1,10 @@
-import type { Element } from 'hast';
+import type { ShikiTransformer } from 'shiki';
 
-export const removeTabIndexFromPre = {
-  pre(node: Element) {
-    node.properties.tabindex = '-1';
+export const removeTabIndexFromPre: ShikiTransformer = {
+  pre(node) {
+    if ('properties' in node) {
+      node.properties.tabindex = '-1';
+    }
+    return node;
   },
 };

--- a/src/styles/tokyo-night.mjs
+++ b/src/styles/tokyo-night.mjs
@@ -1,4 +1,4 @@
-const tokeyoNight = Object.freeze({
+const tokyoNight = Object.freeze({
   colors: {
     'activityBar.background': '#16161e',
     'activityBar.border': '#16161e',
@@ -1839,4 +1839,4 @@ const tokeyoNight = Object.freeze({
   ],
 });
 
-export default tokeyoNight;
+export default tokyoNight;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,15 +5,26 @@
     "allowJs": true,
     "baseUrl": ".",
     "paths": {
-      "@layouts/*": ["src/layouts/*"],
-      "@pages/*": ["src/pages/*"],
-      "@styles/*": ["src/styles/*"],
-      "@components/*": ["src/components/*"],
-      "@hooks/*": ["src/lib/hooks/*"],
-      "@/*": ["src/*"]
+      "@layouts/*": [
+        "src/layouts/*"
+      ],
+      "@pages/*": [
+        "src/pages/*"
+      ],
+      "@styles/*": [
+        "src/styles/*"
+      ],
+      "@components/*": [
+        "src/components/*"
+      ],
+      "@/*": [
+        "src/*"
+      ]
     },
     "jsx": "react-jsx",
     "jsxImportSource": "react"
   },
-  "exclude": ["dist"]
+  "exclude": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
### TL;DR
Improved code block rendering in chat messages by implementing a more reliable inline code detection system.

*this description is written by graphite's AI, it's spot on*

### What changed?
- Replaced the line position-based inline code detection with a DOM structure-based approach
- Added a new `rehypeInlineCodeProperty` plugin to determine if code blocks are inline based on their parent elements
- Modified `CodeHighlight` component to accept an explicit `inline` prop
- Removed dependency on the previous `isInlineCode` utility function

### How to test?
1. Write a message containing both inline code (using single backticks) and code blocks (using triple backticks)
2. Verify that inline code appears properly within the text flow
3. Confirm that code blocks are rendered with proper formatting, language detection, and syntax highlighting
4. Check that the language indicator appears correctly in the top-right corner of code blocks

### Why make this change?
The previous implementation relied on line position data to determine if code was inline, which could be unreliable. The new approach uses the DOM structure to make this determination, providing a more robust and maintainable solution for distinguishing between inline code and code blocks.