### PR TITLE
feat: Refresh ChatUI design

### DIFF
--- a/src/components/ChatUI/ChatBox.tsx
+++ b/src/components/ChatUI/ChatBox.tsx
@@ -43,7 +43,7 @@ export const ChatBox = () => {
     // 177px is the sum of the height of the header and footer
     chatCardHeight: 'min-h-72 max-h-[calc(100dvh-177px)]',
     chatCardWidth:
-      'min-w-64 max-md:w-[calc(100dvw-4rem)] md:w-[clamp(700px,75vw,1000px)]',
+      'min-w-64 max-md:w-[calc(100dvw-4rem)] md:w-[clamp(700px,85vw,1000px)]',
     headerText: 'hidden text-lg mt-2 font-bold leading-none tracking-tight xs:block',
   };
 

--- a/src/components/ChatUI/ChatBox.tsx
+++ b/src/components/ChatUI/ChatBox.tsx
@@ -43,7 +43,7 @@ export const ChatBox = () => {
     // 177px is the sum of the height of the header and footer
     chatCardHeight: 'min-h-72 max-h-[calc(100dvh-177px)]',
     chatCardWidth:
-      'min-w-64 max-md:w-[calc(100dvw-4rem)] md:w-[clamp(700px,85vw,1000px)]',
+      'min-w-64 max-md:w-[calc(100dvw-4rem)] md:w-[clamp(700px,85vw,900px)]',
     headerText: 'hidden text-lg mt-2 font-bold leading-none tracking-tight xs:block',
   };
 

--- a/src/components/ChatUI/ChatBox.tsx
+++ b/src/components/ChatUI/ChatBox.tsx
@@ -40,10 +40,11 @@ export const ChatBox = () => {
   });
 
   const styles: Record<string, string> = {
+    // 177px is the sum of the height of the header and footer
     chatCardHeight: 'min-h-72 max-h-[calc(100dvh-177px)]',
     chatCardWidth:
       'min-w-64 max-md:w-[calc(100dvw-4rem)] md:w-[clamp(700px,75vw,1000px)]',
-    headerText: 'hidden text-lg font-bold leading-none tracking-tight xs:block',
+    headerText: 'hidden text-lg mt-2 font-bold leading-none tracking-tight xs:block',
   };
 
   return (
@@ -53,8 +54,7 @@ export const ChatBox = () => {
         styles.chatCardHeight,
         styles.chatCardWidth
       )}>
-      <CardHeader className="h-18 flex flex-row items-center justify-between py-3">
-        <span className={styles.headerText}>ChatGPT</span>
+      <CardHeader className="flex flex-row justify-between py-3 px-4">
         <ModelSelector />
       </CardHeader>
       <CardContent className="flex flex-col-reverse overflow-y-auto pb-0 pt-2">

--- a/src/components/ChatUI/Messages.tsx
+++ b/src/components/ChatUI/Messages.tsx
@@ -5,16 +5,16 @@ import { CodeHighlight } from './CodeHighlight';
 import type { Message } from '@ai-sdk/react';
 
 const baseMessageStyles: string =
-  'prose prose-slate flex w-max max-w-[75%] flex-col rounded-lg px-3 py-2 prose-p:my-0 prose-pre:my-2 prose-pre:bg-transparent prose-pre:p-0 prose-ul:mt-0';
+  'prose prose-slate flex w-full flex-col px-4 py-2.5 prose-p:my-0 prose-pre:my-2 prose-pre:bg-transparent prose-pre:p-0 prose-ul:mt-0';
 
 const messageStyles: Record<string, Array<string>> = {
   user: [
     baseMessageStyles,
-    'ml-auto bg-primary text-primary-foreground break-words prose-headings:text-primary-foreground prose-code:text-primary-foreground prose-blockquote:text-primary-foreground prose-a:text-primary-foreground prose-strong:text-primary-foreground',
+    'ml-auto bg-accent max-w-[75%] !w-fit rounded-3xl text-foreground break-words prose-headings:text-primary-foreground prose-code:text-primary-foreground prose-blockquote:text-primary-foreground prose-a:text-primary-foreground prose-strong:text-primary-foreground',
   ],
   assistant: [
     baseMessageStyles,
-    'bg-muted dark:prose-invert prose-code:text-foreground',
+    'bg-transparent dark:prose-invert prose-code:text-foreground',
   ],
 };
 
@@ -28,7 +28,7 @@ const RenderedMessage = React.memo(({ message }: { message: Message }) => (
 
 export const ChatMessages = ({ messages }: { messages: Message[] }) => {
   return (
-    <div className='space-y-4'>
+    <div className='space-y-6'>
       {messages.map((message) => (
         <RenderedMessage key={message.id} message={message} />
       ))}

--- a/src/components/ChatUI/Messages.tsx
+++ b/src/components/ChatUI/Messages.tsx
@@ -5,16 +5,15 @@ import { CodeHighlight } from './CodeHighlight';
 import type { Message } from '@ai-sdk/react';
 
 const baseMessageStyles: string =
-  'prose prose-slate flex w-full flex-col px-4 py-2.5 prose-p:my-0 prose-pre:my-2 prose-pre:bg-transparent prose-pre:p-0 prose-ul:mt-0';
-
+  'prose dark:prose-invert text-foreground prose-slate w-full px-4 py-2.5';
 const messageStyles: Record<string, Array<string>> = {
   user: [
     baseMessageStyles,
-    'ml-auto bg-accent max-w-[75%] !w-fit rounded-3xl text-foreground break-words prose-headings:text-primary-foreground prose-code:text-primary-foreground prose-blockquote:text-primary-foreground prose-a:text-primary-foreground prose-strong:text-primary-foreground',
+    'ml-auto bg-accent max-w-[75%] !w-fit rounded-3xl break-words',
   ],
   assistant: [
     baseMessageStyles,
-    'bg-transparent dark:prose-invert prose-code:text-foreground',
+    'bg-transparent min-w-full',
   ],
 };
 

--- a/src/components/ChatUI/ModelSelector.tsx
+++ b/src/components/ChatUI/ModelSelector.tsx
@@ -33,12 +33,13 @@ const modelGroups = [
 type ModelValues = typeof modelGroups[number]['models'][number]['value'];
 
 export const DEFAULT_MODEL: ModelValues = 'gpt-4o-mini';
+
 export const ModelSelector = () => {
   const { selectedModel, setSelectedModel } = useModelContext();
 
   return (
     <Select value={selectedModel} onValueChange={setSelectedModel}>
-      <SelectTrigger className="w-full focus:ring-ring/20 xs:w-[180px]">
+      <SelectTrigger className="focus:ring-ring/20 shadow-none text-[18px] py-5 px-3 cursor-pointer rounded-lg font-semibold border-0 hover:bg-accent w-fit min-w-[180px]">
         <SelectValue placeholder="Select a model" />
       </SelectTrigger>
       <SelectContent>

--- a/src/components/ChatUI/ModelSelector.tsx
+++ b/src/components/ChatUI/ModelSelector.tsx
@@ -39,10 +39,10 @@ export const ModelSelector = () => {
 
   return (
     <Select value={selectedModel} onValueChange={setSelectedModel}>
-      <SelectTrigger className="focus:ring-ring/20 shadow-none text-[18px] py-5 px-3 cursor-pointer rounded-lg font-semibold border-0 hover:bg-accent w-fit min-w-[180px]">
+      <SelectTrigger className="focus:ring-ring/20 focus:bg-accent shadow-none text-[18px] py-5 px-3 cursor-pointer rounded-lg font-semibold border-0 hover:bg-accent data-[state=open]:bg-accent w-fit min-w-[180px]">
         <SelectValue placeholder="Select a model" />
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className='rounded-xl' align='center'>
         {modelGroups.map((group, index) => (
           <SelectGroup key={group.label}>
             <SelectLabel className="text-sm font-bold tracking-wide text-foreground">

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import {
-  CaretSortIcon,
+  CaretDownIcon,
+  // CaretSortIcon,
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
@@ -29,7 +30,8 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <CaretSortIcon className="h-4 w-4 opacity-50" />
+      {/* <CaretSortIcon className="h-4 ml-2 w-4 opacity-50" /> */}
+      <CaretDownIcon className="size-5 ml-2 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
@@ -80,7 +82,7 @@ const SelectContent = React.forwardRef<
       className={cn(
         "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
       )}
       position={position}
@@ -91,7 +93,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+          "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
         )}
       >
         {children}


### PR DESCRIPTION
**feat: Refresh ChatUI design**
- Assistant messages no longer use message bubbles and take full width
- Adjust padding and make user message bubble more rounded
- Removed header text, use enlarged model name instead
- Change icon for select component, remove border and use bg-accent on hover
- Add more space in between messages

**fix: Typography margin collapse issue**
- Removes flex to stop preventing margin collapse
- Remove workaround classes now that margins collapse correctly
- Increase width of chatbox relative to page